### PR TITLE
Support IN clauses with parameters for raw queries

### DIFF
--- a/requery-test/src/main/java/io/requery/test/FunctionalTest.java
+++ b/requery-test/src/main/java/io/requery/test/FunctionalTest.java
@@ -1176,7 +1176,7 @@ public abstract class FunctionalTest extends RandomData {
             data.insert(person);
             people.add(person);
         }
-        List<Long> resultIds = new ArrayList<>();
+        List<Integer> resultIds = new ArrayList<>();
         try (Result<Person> result = data.raw(Person.class, "select * from Person")) {
             List<Person> list = result.toList();
             assertEquals(count, list.size());
@@ -1185,14 +1185,14 @@ public abstract class FunctionalTest extends RandomData {
                 String name = person.getName();
                 assertEquals(people.get(i).getName(), name);
                 assertEquals(people.get(i).getId(), person.getId());
-                resultIds.add(person.getId().longValue());
+                resultIds.add(person.getId());
             }
         }
         try (Result<Person> result = data.raw(Person.class, "select * from Person WHERE id IN ?", resultIds)) {
             List<Person> list = result.toList();
-            List<Long> thisResultIds = new ArrayList<>(list.size());
+            List<Integer> thisResultIds = new ArrayList<>(list.size());
             for (Person tuple : list) {
-                thisResultIds.add(tuple.getId().longValue());
+                thisResultIds.add(tuple.getId());
             }
             assertEquals(resultIds, thisResultIds);
         }

--- a/requery-test/src/main/java/io/requery/test/FunctionalTest.java
+++ b/requery-test/src/main/java/io/requery/test/FunctionalTest.java
@@ -1137,6 +1137,7 @@ public abstract class FunctionalTest extends RandomData {
             data.insert(person);
             people.add(person);
         }
+        List<Long> resultIds = new ArrayList<>();
         try (Result<Tuple> result = data.raw("select * from Person")) {
             List<Tuple> list = result.toList();
             assertEquals(count, list.size());
@@ -1146,7 +1147,16 @@ public abstract class FunctionalTest extends RandomData {
                 assertEquals(people.get(i).getName(), name);
                 Number id = tuple.get("id");
                 assertEquals(people.get(i).getId(), id.intValue());
+                resultIds.add(id.longValue());
             }
+        }
+        try (Result<Tuple> result = data.raw("select * from Person WHERE id IN ?", resultIds)) {
+            List<Tuple> list = result.toList();
+            List<Long> thisResultIds = new ArrayList<>(list.size());
+            for (Tuple tuple : list) {
+                thisResultIds.add(tuple.<Number>get("id").longValue());
+            }
+            assertEquals(resultIds, thisResultIds);
         }
         try (Result<Tuple> result = data.raw("select count(*) from Person")) {
             Number number = result.first().get(0); // can be long or int depending on db
@@ -1166,6 +1176,7 @@ public abstract class FunctionalTest extends RandomData {
             data.insert(person);
             people.add(person);
         }
+        List<Long> resultIds = new ArrayList<>();
         try (Result<Person> result = data.raw(Person.class, "select * from Person")) {
             List<Person> list = result.toList();
             assertEquals(count, list.size());
@@ -1174,7 +1185,16 @@ public abstract class FunctionalTest extends RandomData {
                 String name = person.getName();
                 assertEquals(people.get(i).getName(), name);
                 assertEquals(people.get(i).getId(), person.getId());
+                resultIds.add(person.getId().longValue());
             }
+        }
+        try (Result<Person> result = data.raw(Person.class, "select * from Person WHERE id IN ?", resultIds)) {
+            List<Person> list = result.toList();
+            List<Long> thisResultIds = new ArrayList<>(list.size());
+            for (Person tuple : list) {
+                thisResultIds.add(tuple.getId().longValue());
+            }
+            assertEquals(resultIds, thisResultIds);
         }
         try (Result<Person> result = data.raw(Person.class, "select * from Person WHERE id = ?", people.get(0))) {
             assertEquals(result.first().getId(), people.get(0).getId());

--- a/requery/src/main/java/io/requery/sql/IterableInliner.java
+++ b/requery/src/main/java/io/requery/sql/IterableInliner.java
@@ -1,5 +1,7 @@
 package io.requery.sql;
 
+import io.requery.util.CollectionUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -8,6 +10,9 @@ import java.util.regex.Pattern;
 
 final class IterableInliner {
 
+    /**
+     * Contains the transformed parameters of {@link #inlineIterables(String, Object[])}.
+     */
     static final class IterableInlineResult {
         private String sql;
         private Object[] parameters;
@@ -17,10 +22,17 @@ final class IterableInliner {
             this.sql = sql;
         }
 
+        /**
+         * The parameters where Iterables and Arrays have been inlined.
+         */
         public Object[] getParameters() {
             return parameters;
         }
 
+        /**
+         * The modified SQL statement where question marks
+         * have been added for newly inlined Iterables and Arrays.
+         */
         public String getSql() {
             return sql;
         }
@@ -31,6 +43,17 @@ final class IterableInliner {
     private IterableInliner() {
     }
 
+    /**
+     * Since SQL has no native support for Arrays and Iterables in "IN"-clauses,
+     * this method inlines them. An example: <br/>
+     * <br/>
+     * <code>{@link IterableInlineResult} res = inlineIterables("select * from Person where id in ?", Arrays.asList(1, 2, 3));</code><br/>
+     * <br/>
+     * This is transformed into "select * from Person where id in (?, ?, ?) and the resulting new
+     * parameters are (int, int, int) instead of (List).<br/>
+     * Supported types to be inlined are {@link Iterable}s, Arrays of primitive
+     * and reference types.
+     */
     static IterableInlineResult inlineIterables(String sql, Object[] parameters) {
         List<Integer> indicesOfArguments = new ArrayList<>(parameters.length);
         Matcher matcher = questionMarkPattern.matcher(sql);
@@ -39,35 +62,37 @@ final class IterableInliner {
         }
 
         StringBuilder inlineBuilder = new StringBuilder(sql);
-        List<Object> newParameters = new ArrayList<>(Arrays.asList(parameters));
+        List<Object> newParameters = new ArrayList<>(Arrays.asList(parameters)); // Modifiable copy
 
+        // Iterate backwords to avoid modifying the indices of
+        // parameters in the front
         for (int i = parameters.length - 1; i >= 0; i--) {
             Object parameter = parameters[i];
             int argumentStringIndex = indicesOfArguments.get(i);
 
             if (parameter instanceof Iterable) {
                 //noinspection unchecked
-                List<Object> objects = toList((Iterable<Object>) parameter);
+                List<Object> objects = CollectionUtils.toList((Iterable<Object>) parameter);
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(objects.size()));
                 newParameters.addAll(0, objects);
             } else if (parameter instanceof byte[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((byte[]) parameter).length));
-                newParameters.addAll(0, toList(((byte[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((byte[]) parameter)));
             } else if (parameter instanceof short[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((short[]) parameter).length));
-                newParameters.addAll(0, toList(((short[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((short[]) parameter)));
             } else if (parameter instanceof int[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((int[]) parameter).length));
-                newParameters.addAll(0, toList(((int[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((int[]) parameter)));
             } else if (parameter instanceof long[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((long[]) parameter).length));
-                newParameters.addAll(0, toList(((long[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((long[]) parameter)));
             } else if (parameter instanceof float[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((float[]) parameter).length));
-                newParameters.addAll(0, toList(((float[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((float[]) parameter)));
             } else if (parameter instanceof double[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((double[]) parameter).length));
-                newParameters.addAll(0, toList(((double[]) parameter)));
+                newParameters.addAll(0, CollectionUtils.toList(((double[]) parameter)));
             } else if (parameter instanceof Object[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((Object[]) parameter).length));
                 newParameters.addAll(0, Arrays.asList((Object[]) parameter));
@@ -79,66 +104,10 @@ final class IterableInliner {
         return new IterableInlineResult(newParameters.toArray(), inlineBuilder.toString());
     }
 
-    private static List<Byte> toList(byte[] arr) {
-        List<Byte> list = new ArrayList<>(arr.length);
-        for (byte value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static List<Short> toList(short[] arr) {
-        List<Short> list = new ArrayList<>(arr.length);
-        for (short value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static List<Integer> toList(int[] arr) {
-        List<Integer> list = new ArrayList<>(arr.length);
-        for (int value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static List<Long> toList(long[] arr) {
-        List<Long> list = new ArrayList<>(arr.length);
-        for (long value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static List<Float> toList(float[] arr) {
-        List<Float> list = new ArrayList<>(arr.length);
-        for (float value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static List<Double> toList(double[] arr) {
-        List<Double> list = new ArrayList<>(arr.length);
-        for (double value : arr) {
-            list.add(value);
-        }
-        return list;
-    }
-
-    private static <T> List<T> toList(Iterable<T> iterable) {
-        if (iterable instanceof List) {
-            return (List<T>) iterable;
-        }
-
-        List<T> list = new ArrayList<>();
-        for (T t : iterable) {
-            list.add(t);
-        }
-        return list;
-    }
-
+    /**
+     * Build a String of the form "(?, ?, ..., ?)" where the number
+     * of question marks is length.
+     */
     private static String argumentTuple(int length) {
         StringBuilder sb = new StringBuilder("(");
         for (int i = 0; i < length; i++) {

--- a/requery/src/main/java/io/requery/sql/IterableInliner.java
+++ b/requery/src/main/java/io/requery/sql/IterableInliner.java
@@ -62,7 +62,7 @@ final class IterableInliner {
         }
 
         StringBuilder inlineBuilder = new StringBuilder(sql);
-        List<Object> newParameters = new ArrayList<>(Arrays.asList(parameters)); // Modifiable copy
+        List<Object> newParameters = new ArrayList<>(); // Modifiable copy
 
         // Iterate backwords to avoid modifying the indices of
         // parameters in the front

--- a/requery/src/main/java/io/requery/sql/IterableInliner.java
+++ b/requery/src/main/java/io/requery/sql/IterableInliner.java
@@ -115,7 +115,7 @@ final class IterableInliner {
 
     private static boolean containsIterableOrArray(Object[] parameters) {
         for (Object parameter : parameters) {
-            if (parameter instanceof Iterable || parameter.getClass().isArray()) {
+            if (parameter instanceof Iterable || parameter != null && parameter.getClass().isArray()) {
                 return true;
             }
         }

--- a/requery/src/main/java/io/requery/sql/IterableInliner.java
+++ b/requery/src/main/java/io/requery/sql/IterableInliner.java
@@ -96,6 +96,12 @@ final class IterableInliner {
             } else if (parameter instanceof double[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((double[]) parameter).length));
                 CollectionUtils.insertIntoListBeginning((double[]) parameter, newParameters);
+            } else if (parameter instanceof boolean[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((boolean[]) parameter).length));
+                CollectionUtils.insertIntoListBeginning((boolean[]) parameter, newParameters);
+            } else if (parameter instanceof char[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((char[]) parameter).length));
+                CollectionUtils.insertIntoListBeginning((char[]) parameter, newParameters);
             } else if (parameter instanceof Object[]) {
                 inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((Object[]) parameter).length));
                 CollectionUtils.insertIntoListBeginning((Object[]) parameter, newParameters);

--- a/requery/src/main/java/io/requery/sql/IterableInliner.java
+++ b/requery/src/main/java/io/requery/sql/IterableInliner.java
@@ -1,0 +1,154 @@
+package io.requery.sql;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class IterableInliner {
+
+    static final class IterableInlineResult {
+        private String sql;
+        private Object[] parameters;
+
+        private IterableInlineResult(Object[] parameters, String sql) {
+            this.parameters = parameters;
+            this.sql = sql;
+        }
+
+        public Object[] getParameters() {
+            return parameters;
+        }
+
+        public String getSql() {
+            return sql;
+        }
+    }
+
+    private static final Pattern questionMarkPattern = Pattern.compile("\\?");
+
+    private IterableInliner() {
+    }
+
+    static IterableInlineResult inlineIterables(String sql, Object[] parameters) {
+        List<Integer> indicesOfArguments = new ArrayList<>(parameters.length);
+        Matcher matcher = questionMarkPattern.matcher(sql);
+        while (matcher.find()) {
+            indicesOfArguments.add(matcher.start());
+        }
+
+        StringBuilder inlineBuilder = new StringBuilder(sql);
+        List<Object> newParameters = new ArrayList<>(Arrays.asList(parameters));
+
+        for (int i = parameters.length - 1; i >= 0; i--) {
+            Object parameter = parameters[i];
+            int argumentStringIndex = indicesOfArguments.get(i);
+
+            if (parameter instanceof Iterable) {
+                //noinspection unchecked
+                List<Object> objects = toList((Iterable<Object>) parameter);
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(objects.size()));
+                newParameters.addAll(0, objects);
+            } else if (parameter instanceof byte[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((byte[]) parameter).length));
+                newParameters.addAll(0, toList(((byte[]) parameter)));
+            } else if (parameter instanceof short[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((short[]) parameter).length));
+                newParameters.addAll(0, toList(((short[]) parameter)));
+            } else if (parameter instanceof int[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((int[]) parameter).length));
+                newParameters.addAll(0, toList(((int[]) parameter)));
+            } else if (parameter instanceof long[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((long[]) parameter).length));
+                newParameters.addAll(0, toList(((long[]) parameter)));
+            } else if (parameter instanceof float[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((float[]) parameter).length));
+                newParameters.addAll(0, toList(((float[]) parameter)));
+            } else if (parameter instanceof double[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((double[]) parameter).length));
+                newParameters.addAll(0, toList(((double[]) parameter)));
+            } else if (parameter instanceof Object[]) {
+                inlineBuilder.replace(argumentStringIndex, argumentStringIndex + 1, argumentTuple(((Object[]) parameter).length));
+                newParameters.addAll(0, Arrays.asList((Object[]) parameter));
+            } else {
+                newParameters.add(0, parameter);
+            }
+        }
+
+        return new IterableInlineResult(newParameters.toArray(), inlineBuilder.toString());
+    }
+
+    private static List<Byte> toList(byte[] arr) {
+        List<Byte> list = new ArrayList<>(arr.length);
+        for (byte value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static List<Short> toList(short[] arr) {
+        List<Short> list = new ArrayList<>(arr.length);
+        for (short value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static List<Integer> toList(int[] arr) {
+        List<Integer> list = new ArrayList<>(arr.length);
+        for (int value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static List<Long> toList(long[] arr) {
+        List<Long> list = new ArrayList<>(arr.length);
+        for (long value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static List<Float> toList(float[] arr) {
+        List<Float> list = new ArrayList<>(arr.length);
+        for (float value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static List<Double> toList(double[] arr) {
+        List<Double> list = new ArrayList<>(arr.length);
+        for (double value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    private static <T> List<T> toList(Iterable<T> iterable) {
+        if (iterable instanceof List) {
+            return (List<T>) iterable;
+        }
+
+        List<T> list = new ArrayList<>();
+        for (T t : iterable) {
+            list.add(t);
+        }
+        return list;
+    }
+
+    private static String argumentTuple(int length) {
+        StringBuilder sb = new StringBuilder("(");
+        for (int i = 0; i < length; i++) {
+            sb.append("?");
+            if (i + 1 < length) {
+                sb.append(", ");
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+}

--- a/requery/src/main/java/io/requery/sql/RawEntityQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawEntityQuery.java
@@ -54,10 +54,11 @@ class RawEntityQuery<E extends S, S> extends PreparedQueryOperation implements
                    Class<E> cls, String sql, Object[] parameters) {
         super(context, null);
         EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
+        IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
         this.type = configuration.model().typeOf(cls);
-        this.sql = sql;
+        this.sql = iterableInlineResult.getSql();
         this.reader = context.read(cls);
-        boundParameters = new BoundParameters(parameters);
+        boundParameters = new BoundParameters(iterableInlineResult.getParameters());
     }
 
     @Override

--- a/requery/src/main/java/io/requery/sql/RawEntityQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawEntityQuery.java
@@ -53,8 +53,8 @@ class RawEntityQuery<E extends S, S> extends PreparedQueryOperation implements
     RawEntityQuery(EntityContext<S> context,
                    Class<E> cls, String sql, Object[] parameters) {
         super(context, null);
-        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         this.type = configuration.model().typeOf(cls);
         this.sql = iterableInlineResult.getSql();
         this.reader = context.read(cls);

--- a/requery/src/main/java/io/requery/sql/RawEntityQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawEntityQuery.java
@@ -54,7 +54,7 @@ class RawEntityQuery<E extends S, S> extends PreparedQueryOperation implements
                    Class<E> cls, String sql, Object[] parameters) {
         super(context, null);
         IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
-        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, iterableInlineResult.getParameters());
         this.type = configuration.model().typeOf(cls);
         this.sql = iterableInlineResult.getSql();
         this.reader = context.read(cls);

--- a/requery/src/main/java/io/requery/sql/RawTupleQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawTupleQuery.java
@@ -49,7 +49,7 @@ class RawTupleQuery extends PreparedQueryOperation implements Supplier<Result<Tu
     RawTupleQuery(RuntimeConfiguration configuration, String sql, Object[] parameters) {
         super(configuration, null);
         IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
-        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, iterableInlineResult.getParameters());
         this.sql = iterableInlineResult.getSql();
         queryType = queryTypeOf(sql);
         boundParameters = new BoundParameters(iterableInlineResult.getParameters());

--- a/requery/src/main/java/io/requery/sql/RawTupleQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawTupleQuery.java
@@ -49,9 +49,10 @@ class RawTupleQuery extends PreparedQueryOperation implements Supplier<Result<Tu
     RawTupleQuery(RuntimeConfiguration configuration, String sql, Object[] parameters) {
         super(configuration, null);
         EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
-        this.sql = sql;
+        IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
+        this.sql = iterableInlineResult.getSql();
         queryType = queryTypeOf(sql);
-        boundParameters = new BoundParameters(parameters);
+        boundParameters = new BoundParameters(iterableInlineResult.getParameters());
     }
 
     private static QueryType queryTypeOf(String sql) {

--- a/requery/src/main/java/io/requery/sql/RawTupleQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawTupleQuery.java
@@ -48,8 +48,8 @@ class RawTupleQuery extends PreparedQueryOperation implements Supplier<Result<Tu
 
     RawTupleQuery(RuntimeConfiguration configuration, String sql, Object[] parameters) {
         super(configuration, null);
-        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         this.sql = iterableInlineResult.getSql();
         queryType = queryTypeOf(sql);
         boundParameters = new BoundParameters(iterableInlineResult.getParameters());

--- a/requery/src/main/java/io/requery/util/CollectionUtils.java
+++ b/requery/src/main/java/io/requery/util/CollectionUtils.java
@@ -1,0 +1,91 @@
+package io.requery.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class for {@link java.util.Collection} objects
+ * and (primitive) arrays.
+ */
+public final class CollectionUtils {
+
+    private CollectionUtils() {
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Byte> toList(byte[] arr) {
+        List<Byte> list = new ArrayList<>(arr.length);
+        for (byte value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Short> toList(short[] arr) {
+        List<Short> list = new ArrayList<>(arr.length);
+        for (short value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Integer> toList(int[] arr) {
+        List<Integer> list = new ArrayList<>(arr.length);
+        for (int value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Long> toList(long[] arr) {
+        List<Long> list = new ArrayList<>(arr.length);
+        for (long value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Float> toList(float[] arr) {
+        List<Float> list = new ArrayList<>(arr.length);
+        for (float value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the array into a modifiable list.
+     */
+    public static List<Double> toList(double[] arr) {
+        List<Double> list = new ArrayList<>(arr.length);
+        for (double value : arr) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    /**
+     * Copies the {@link Iterable} into a modifiable list.
+     */
+    public static <T> List<T> toList(Iterable<T> iterable) {
+        List<T> list = new ArrayList<>();
+        for (T t : iterable) {
+            list.add(t);
+        }
+        return list;
+    }
+}

--- a/requery/src/main/java/io/requery/util/CollectionUtils.java
+++ b/requery/src/main/java/io/requery/util/CollectionUtils.java
@@ -13,79 +13,87 @@ public final class CollectionUtils {
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Byte> toList(byte[] arr) {
-        List<Byte> list = new ArrayList<>(arr.length);
-        for (byte value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(byte[] arr, ArrayList<? super Byte> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Short> toList(short[] arr) {
-        List<Short> list = new ArrayList<>(arr.length);
-        for (short value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(short[] arr, ArrayList<? super Short> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Integer> toList(int[] arr) {
-        List<Integer> list = new ArrayList<>(arr.length);
-        for (int value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(int[] arr, ArrayList<? super Integer> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Long> toList(long[] arr) {
-        List<Long> list = new ArrayList<>(arr.length);
-        for (long value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(long[] arr, ArrayList<? super Long> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Float> toList(float[] arr) {
-        List<Float> list = new ArrayList<>(arr.length);
-        for (float value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(float[] arr, ArrayList<? super Float> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the array into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static List<Double> toList(double[] arr) {
-        List<Double> list = new ArrayList<>(arr.length);
-        for (double value : arr) {
-            list.add(value);
+    public static void insertIntoListBeginning(double[] arr, ArrayList<? super Double> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
         }
-        return list;
     }
 
     /**
-     * Copies the {@link Iterable} into a modifiable list.
+     * Inserts the array at index 0 in the supplied list.
      */
-    public static <T> List<T> toList(Iterable<T> iterable) {
-        List<T> list = new ArrayList<>();
+    public static void insertIntoListBeginning(Object[] arr, ArrayList<Object> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
+        }
+    }
+
+    /**
+     * Inserts the {@link Iterable} at index 0 in the supplied list.
+     */
+    public static <T> void insertIntoListBeginning(Iterable<T> iterable, ArrayList<? super T> list) {
+        if (iterable instanceof List) {
+            list.addAll(0, (List<T>) iterable);
+            return;
+        }
+
+        int i = 0;
         for (T t : iterable) {
-            list.add(t);
+            list.add(i++, t);
         }
-        return list;
     }
 }

--- a/requery/src/main/java/io/requery/util/CollectionUtils.java
+++ b/requery/src/main/java/io/requery/util/CollectionUtils.java
@@ -83,6 +83,26 @@ public final class CollectionUtils {
     }
 
     /**
+     * Inserts the array at index 0 in the supplied list.
+     */
+    public static void insertIntoListBeginning(boolean[] arr, ArrayList<Object> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
+        }
+    }
+
+    /**
+     * Inserts the array at index 0 in the supplied list.
+     */
+    public static void insertIntoListBeginning(char[] arr, ArrayList<Object> list) {
+        list.ensureCapacity(list.size() + arr.length);
+        for (int i = arr.length - 1; i >= 0; i--) {
+            list.add(0, arr[i]);
+        }
+    }
+
+    /**
      * Inserts the {@link Iterable} at index 0 in the supplied list.
      */
     public static <T> void insertIntoListBeginning(Iterable<T> iterable, ArrayList<? super T> list) {


### PR DESCRIPTION
As described in issue #62, support IN clauses with iterable/array parameters. See `IterableInliner.inlineIterables(String, Object[])` for details.

**When merged in conjunction with #80, be sure to call `EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);` AFTER `IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);` in `RawTupleQuery` and `RawEntityQuery` constructors.**