### PR TITLE
Map database entities to their keys when used as parameters

### DIFF
--- a/requery-test/src/main/java/io/requery/test/FunctionalTest.java
+++ b/requery-test/src/main/java/io/requery/test/FunctionalTest.java
@@ -1152,6 +1152,9 @@ public abstract class FunctionalTest extends RandomData {
             Number number = result.first().get(0); // can be long or int depending on db
             assertEquals(count, number.intValue());
         }
+        try (Result<Tuple> result = data.raw("select * from Person WHERE id = ?", people.get(0))) {
+            assertEquals(result.first().<Number>get("id").intValue(), people.get(0).getId());
+        }
     }
 
     @Test
@@ -1172,6 +1175,9 @@ public abstract class FunctionalTest extends RandomData {
                 assertEquals(people.get(i).getName(), name);
                 assertEquals(people.get(i).getId(), person.getId());
             }
+        }
+        try (Result<Person> result = data.raw(Person.class, "select * from Person WHERE id = ?", people.get(0))) {
+            assertEquals(result.first().getId(), people.get(0).getId());
         }
     }
 

--- a/requery/src/main/java/io/requery/meta/EntityModel.java
+++ b/requery/src/main/java/io/requery/meta/EntityModel.java
@@ -40,6 +40,16 @@ public interface EntityModel {
     <T> Type<T> typeOf(Class<? extends T> entityClass) throws NotMappedException;
 
     /**
+     * Check if the meta {@link Type} information for the given entity class
+     * is contained in this {@link EntityModel}.
+     *
+     * @param entityClass entity class
+     * @param <T>         entity type
+     * @return True, iff the {@link Type} representing the given entity class exists.
+     */
+    <T> boolean containsTypeOf(Class<? extends T> entityClass);
+
+    /**
      * @return Read only collection of all {@link Type} elements in this model.
      */
     Set<Type<?>> allTypes();

--- a/requery/src/main/java/io/requery/meta/ImmutableEntityModel.java
+++ b/requery/src/main/java/io/requery/meta/ImmutableEntityModel.java
@@ -55,6 +55,11 @@ final class ImmutableEntityModel implements EntityModel {
     }
 
     @Override
+    public <T> boolean containsTypeOf(Class<? extends T> entityClass) {
+        return map.containsKey(entityClass);
+    }
+
+    @Override
     public Set<Type<?>> allTypes() {
         return new LinkedHashSet<>(map.values());
     }

--- a/requery/src/main/java/io/requery/sql/EntityKeyMapper.java
+++ b/requery/src/main/java/io/requery/sql/EntityKeyMapper.java
@@ -1,0 +1,35 @@
+package io.requery.sql;
+
+import io.requery.meta.Attribute;
+import io.requery.meta.Type;
+
+/**
+ * @see #mapEntitiesToKeys(RuntimeConfiguration, Object[])
+ */
+final class EntityKeyMapper {
+
+    private EntityKeyMapper() {
+    }
+
+    /**
+     * Map objects that are database entities with a single key in the parameter array to
+     * their single key.
+     * <p>
+     * Modifies the supplied array.
+     */
+    static void mapEntitiesToKeys(RuntimeConfiguration configuration, Object[] parameters) {
+        for (int i = 0; i < parameters.length; i++) {
+            Object param = parameters[i];
+            boolean isEntity = configuration.model().containsTypeOf(param.getClass());
+            if (isEntity) {
+                Type<Object> objectType = configuration.model().typeOf(param.getClass());
+                Attribute<Object, ?> singleKeyAttribute = objectType.singleKeyAttribute();
+                if (singleKeyAttribute != null) {
+                    Object key = singleKeyAttribute.property().get(param);
+                    parameters[i] = key;
+                }
+            }
+        }
+    }
+
+}

--- a/requery/src/main/java/io/requery/sql/RawEntityQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawEntityQuery.java
@@ -53,6 +53,7 @@ class RawEntityQuery<E extends S, S> extends PreparedQueryOperation implements
     RawEntityQuery(EntityContext<S> context,
                    Class<E> cls, String sql, Object[] parameters) {
         super(context, null);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         this.type = configuration.model().typeOf(cls);
         this.sql = sql;
         this.reader = context.read(cls);

--- a/requery/src/main/java/io/requery/sql/RawTupleQuery.java
+++ b/requery/src/main/java/io/requery/sql/RawTupleQuery.java
@@ -48,6 +48,7 @@ class RawTupleQuery extends PreparedQueryOperation implements Supplier<Result<Tu
 
     RawTupleQuery(RuntimeConfiguration configuration, String sql, Object[] parameters) {
         super(configuration, null);
+        EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);
         this.sql = sql;
         queryType = queryTypeOf(sql);
         boundParameters = new BoundParameters(parameters);


### PR DESCRIPTION
As described in [this](https://github.com/requery/requery/issues/62#issuecomment-208263274) comment in issue #61, after this change parameters for raw queries are now mapped to keys for objects that are database entities with a single key.

**When merged in conjunction with #79, be sure to call `EntityKeyMapper.mapEntitiesToKeys(configuration, parameters);` AFTER `IterableInliner.IterableInlineResult iterableInlineResult = IterableInliner.inlineIterables(sql, parameters);` in `RawTupleQuery` and `RawEntityQuery` constructors.**