### PR TITLE
Fix CompletableEntityStore upsert operation

### DIFF
--- a/requery/src/main/java/io/requery/async/CompletableEntityStore.java
+++ b/requery/src/main/java/io/requery/async/CompletableEntityStore.java
@@ -120,7 +120,7 @@ public class CompletableEntityStore<T> implements CompletionStageEntityStore<T> 
         return CompletableFuture.supplyAsync(new Supplier<E>() {
             @Override
             public E get() {
-                return delegate.update(entity);
+                return delegate.upsert(entity);
             }
         }, executor);
     }


### PR DESCRIPTION
Calling upsert on a CompletableEntityStore resulted in an update operation being executed, since the wrong delegate method was called. This PR fixes this by simply changing update to upsert.