### PR TITLE
Fix SQL in certain locales

### DIFF
--- a/requery-processor/src/main/java/io/requery/processor/AttributeMember.java
+++ b/requery-processor/src/main/java/io/requery/processor/AttributeMember.java
@@ -73,6 +73,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -500,7 +501,7 @@ class AttributeMember extends BaseProcessableElement<Element> implements Attribu
             String name = methodElement.getSimpleName().toString();
             name = Names.removeMethodPrefixes(name);
             if (Names.isAllUpper(name)) {
-                return name.toLowerCase();
+                return name.toLowerCase(Locale.US);
             } else {
                 return Names.lowerCaseFirst(name);
             }
@@ -532,7 +533,7 @@ class AttributeMember extends BaseProcessableElement<Element> implements Attribu
                 if (parameters.size() == 1) {
                     String property =
                         Names.removeMethodPrefixes(element.getSimpleName().toString());
-                    if (property.toLowerCase().equalsIgnoreCase(name())) {
+                    if (property.toLowerCase(Locale.US).equalsIgnoreCase(name())) {
                         return element.getSimpleName().toString();
                     }
                 }

--- a/requery-processor/src/main/java/io/requery/processor/EntityGraph.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityGraph.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -90,7 +91,7 @@ class EntityGraph {
             // match by type name
             Optional<TypeKind> primitiveType = Stream.of(TypeKind.values())
                 .filter(TypeKind::isPrimitive)
-                .filter(kind -> kind.toString().toLowerCase().equals(attribute.referencedType()))
+                .filter(kind -> kind.toString().toLowerCase(Locale.US).equals(attribute.referencedType()))
                 .findFirst();
             if (primitiveType.isPresent()) {
                 // attribute is basic foreign key and not referring to an entity

--- a/requery-processor/src/main/java/io/requery/processor/EntityGraph.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityGraph.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -91,7 +90,7 @@ class EntityGraph {
             // match by type name
             Optional<TypeKind> primitiveType = Stream.of(TypeKind.values())
                 .filter(TypeKind::isPrimitive)
-                .filter(kind -> kind.toString().toLowerCase(Locale.US).equals(attribute.referencedType()))
+                .filter(kind -> kind.toString().toLowerCase().equals(attribute.referencedType()))
                 .findFirst();
             if (primitiveType.isPresent()) {
                 // attribute is basic foreign key and not referring to an entity

--- a/requery-test/src/test/java/io/requery/test/DatabaseType.java
+++ b/requery-test/src/test/java/io/requery/test/DatabaseType.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 import java.util.Properties;
 
 /**
@@ -133,7 +134,7 @@ public enum DatabaseType {
                     .asSubclass(CommonDataSource.class);
             }
             CommonDataSource dataSource = dataSourceClass.newInstance();
-            String fileName = platformClass.getSimpleName().toLowerCase();
+            String fileName = platformClass.getSimpleName().toLowerCase(Locale.US);
             Properties properties = new Properties();
             String localPath = "src/test/resources/io/requery/test/local/";
             String ciPath = "src/test/resources/io/requery/test/ci/";

--- a/requery/src/main/java/io/requery/sql/QueryBuilder.java
+++ b/requery/src/main/java/io/requery/sql/QueryBuilder.java
@@ -16,12 +16,12 @@
 
 package io.requery.sql;
 
+import io.requery.meta.Attribute;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
-
-import io.requery.meta.Attribute;
 
 /**
  * String Builder for creating SQL statements.

--- a/requery/src/main/java/io/requery/sql/QueryBuilder.java
+++ b/requery/src/main/java/io/requery/sql/QueryBuilder.java
@@ -16,11 +16,12 @@
 
 package io.requery.sql;
 
-import io.requery.meta.Attribute;
-
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
+
+import io.requery.meta.Attribute;
 
 /**
  * String Builder for creating SQL statements.
@@ -85,7 +86,7 @@ public class QueryBuilder implements CharSequence {
 
     public QueryBuilder keyword(Keyword... keywords) {
         for (Keyword keyword : keywords) {
-            sb.append(options.lowercaseKeywords ? keyword.toString().toLowerCase() : keyword);
+            sb.append(options.lowercaseKeywords ? keyword.toString().toLowerCase(Locale.US) : keyword);
             sb.append(" ");
         }
         return this;
@@ -139,7 +140,7 @@ public class QueryBuilder implements CharSequence {
         } else {
             if (value instanceof Keyword) {
                 sb.append(options.lowercaseKeywords ?
-                        value.toString().toLowerCase() : value.toString());
+                        value.toString().toLowerCase(Locale.US) : value.toString());
             } else {
                 sb.append(value.toString());
             }


### PR DESCRIPTION
1. I received bug reports of `PRIMARY` being compiled to `prımary` (dotless i), causing errors. Using the US locale for String.toLowerCase() should fix that.  
2. ~~Updated all dependencies (except for bintray release, seems to cause compilation errors with Shadow).~~