### PR TITLE
Fix the rules of android proguard

### DIFF
--- a/requery-android/proguard-rules.pro
+++ b/requery-android/proguard-rules.pro
@@ -8,6 +8,8 @@
 -dontwarn java.sql.**
 -dontwarn io.requery.cache.**
 -dontwarn io.requery.rx.**
+-dontwarn io.requery.android.sqlcipher.**
+-dontwarn io.requery.android.sqlitex.**
 -keepclassmembers enum io.requery.** {
     public static **[] values();
     public static ** valueOf(java.lang.String);


### PR DESCRIPTION
With the commit 104668cfc1e5d544271f639b2c413030b78949c4, the rules of android proguard are simplified, but it lacks rules for configurations that do not have the `sqlcipher` and `sqlitex` libraries.