### PR TITLE
Fix unmarshalling of custom Parcelables

### DIFF
--- a/requery-android/src/main/java/io/requery/android/EntityParceler.java
+++ b/requery-android/src/main/java/io/requery/android/EntityParceler.java
@@ -47,7 +47,7 @@ public class EntityParceler<T> {
             Class<?> typeClass = attribute.getClassType();
             Object value;
             if (typeClass.isEnum()) {
-                String name = (String) in.readValue(null);
+                String name = (String) in.readValue(getClass().getClassLoader());
                 if (name == null) {
                     value = null;
                 } else {
@@ -56,7 +56,7 @@ public class EntityParceler<T> {
                     value = Enum.valueOf(enumClass, name);
                 }
             } else {
-                value = in.readValue(null);
+                value = in.readValue(getClass().getClassLoader());
             }
             PropertyState state = PropertyState.LOADED;
             if (!type.isStateless()) {


### PR DESCRIPTION
When reading values from a `Parcel`, one should always pass the application classloader to `readValue`. If `null` is passed, the Android framework uses the system classloader, which can only load classes from the framework, while the application classloader can load these and classes from the application itself.