### PR TITLE
Explain when a property is considered modified

### DIFF
--- a/requery/src/main/java/io/requery/EntityStore.java
+++ b/requery/src/main/java/io/requery/EntityStore.java
@@ -90,7 +90,9 @@ public interface EntityStore<T, R> extends Queryable<T>, AutoCloseable {
 
     /**
      * Update the given entity. If the given entity has modified properties those changes will be
-     * persisted otherwise the method will do nothing.
+     * persisted otherwise the method will do nothing. A property is considered modified
+     * if its associated setter has been called, so only modifying the state of a property's content
+     * will not cause an update to happen.
      *
      * @param entity to update
      * @param <E>    entity type


### PR DESCRIPTION
When using `update(E entity)`, I was confused to not see an `UPDATE` being sent to the database when only modifying the state of a property's content, for example adding an entry to a HashMap that is serialized with a `Converter`. I've taken a look at the source code and noticed that a property is only considered modified if its associated setter has been called. This PR updates the documentation of `update(E entity)` to reflect this behavior.