### PR TITLE
Fixed: prefix not being removed when field is used as association

### DIFF
--- a/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
@@ -398,7 +398,8 @@ class EntityMetaGenerator extends EntityPartGenerator {
                 }
                 if (mappings.size() == 1) {
                     AttributeDescriptor mapped = mappings.iterator().next();
-                    String staticMemberName = Names.upperCaseUnderscore(mapped.fieldName());
+                    String staticMemberName = Names.upperCaseUnderscore(
+                            Names.removeMemberPrefixes(mapped.fieldName()));
 
                     TypeSpec provider = CodeGeneration.createAnonymousSupplier(
                         ClassName.get(Attribute.class),


### PR DESCRIPTION
### Problem:
The 'm' prefix is not being removed in the generated code for an association entity.

### How to Solve:
Calling `Names#removeMemberPrefixes` when attribute names are resolved.