### PR TITLE
Resolve #247 Fixed upsert on sqlite

### DIFF
--- a/requery/src/main/java/io/requery/sql/EntityWriter.java
+++ b/requery/src/main/java/io/requery/sql/EntityWriter.java
@@ -479,14 +479,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                 }
             } else {
                 // not a real upsert, but can be ok for embedded databases
-                Predicate<Attribute<E, ?>> forceUpdate = new Predicate<Attribute<E, ?>>() {
-                    @Override
-                    public boolean test(Attribute<E, ?> value) {
-                        return true;
-                    }
-                };
-
-                int updateResult = update(entity, proxy, Cascade.UPSERT, forceUpdate, null);
+                int updateResult = update(entity, proxy, Cascade.UPSERT, null, null);
                 if (updateResult == -1 || updateResult == 0) {
                     insert(entity, proxy, Cascade.UPSERT, null);
                 }


### PR DESCRIPTION
#247 Upsert was not working properly on Android with Sqlite.

Deserialized Entity (eg. obtained from api and deserialized with gson) was not correctly upserted. `update()` method returned `-1` what was not handled inside `upsert()` method.
For not upsert-enabled databases first we force update, then if it nothing was updated, we do `insert()`. 
