### PR TITLE
Resolve #232 Support repeated @Embedded fields

### DIFF
--- a/requery-processor/src/main/java/io/requery/processor/EntityGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityGenerator.java
@@ -386,7 +386,7 @@ class EntityGenerator extends EntityPartGenerator implements SourceGenerator {
             .forEach(attribute -> graph.embeddedDescriptorOf(attribute).ifPresent(embedded -> {
                 ClassName embeddedName = nameResolver.embeddedTypeNameOf(embedded, entity);
                 String format = embedded.attributes().values().stream().map(attr ->
-                        Names.upperCaseUnderscore(Names.removeMemberPrefixes(attr.fieldName())))
+                        Names.upperCaseUnderscore(embeddedAttributeName(attribute, attr)))
                         .collect(Collectors.joining(", ", "$L = new $T($L, ", ")"));
                 constructor.addStatement(format.toString(),
                     attribute.fieldName(), embeddedName, PROXY_NAME);

--- a/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
@@ -221,7 +221,7 @@ class EntityMetaGenerator extends EntityPartGenerator {
                                             TypeName targetName) {
         // generate the embedded attributes into this type
         embedded.attributes().values().forEach(attribute -> {
-            String fieldName = upperCaseUnderscoreRemovePrefixes(attribute.fieldName());
+            String fieldName = Names.upperCaseUnderscore(embeddedAttributeName(parent, attribute));
             TypeMirror mirror = attribute.typeMirror();
             builder.addField(
                 generateAttribute(attribute, parent, targetName, fieldName, mirror, false));
@@ -279,6 +279,10 @@ class EntityMetaGenerator extends EntityPartGenerator {
         }
 
         CodeBlock.Builder builder = CodeBlock.builder();
+        String attributeName = attribute.name();
+        if (parent != null && parent.isEmbedded()) {
+            attributeName = embeddedAttributeName(parent, attribute);
+        }
 
         if (attribute.isIterable()) {
             typeMirror = tryFirstTypeArgument(typeMirror);
@@ -289,7 +293,7 @@ class EntityMetaGenerator extends EntityPartGenerator {
                 attribute.builderClass(), targetName, typeName, name);
 
             builder.add("\nnew $T($S, $T.class, $T.class)\n",
-                builderName, attribute.name(), ClassName.get(collection), name);
+                builderName, attributeName, ClassName.get(collection), name);
 
         } else if (attribute.isMap() && attribute.cardinality() != null) {
             List<TypeMirror> parameters = Mirrors.listGenericTypeArguments(typeMirror);
@@ -303,7 +307,7 @@ class EntityMetaGenerator extends EntityPartGenerator {
                 attribute.builderClass(), targetName, typeName, keyName, valueName);
 
             builder.add("\nnew $T($S, $T.class, $T.class, $T.class)\n", builderName,
-                attribute.name(), ClassName.get(valueElement), keyName, valueName);
+                attributeName, ClassName.get(valueElement), keyName, valueName);
         } else {
             ParameterizedTypeName builderName = parameterizedTypeName(
                 attribute.builderClass(), targetName, typeName);
@@ -320,7 +324,7 @@ class EntityMetaGenerator extends EntityPartGenerator {
             } else {
                 statement ="\nnew $T($S, $T.class)\n";
             }
-            builder.add(statement, builderName, attribute.name(), classType);
+            builder.add(statement, builderName, attributeName, classType);
         }
         if (!expression) {
             generateProperties(attribute, parent, typeMirror, targetName, typeName, builder);

--- a/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityMetaGenerator.java
@@ -55,6 +55,7 @@ import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -79,6 +80,7 @@ class EntityMetaGenerator extends EntityPartGenerator {
         boolean metadataOnly = entity.isImmutable() || entity.isUnimplementable();
         TypeName targetName = metadataOnly? ClassName.get(entity.element()) : typeName;
 
+        List<QualifiedName> generatedEmbeddedTypes = new LinkedList<>();
         entity.attributes().values().stream()
             .filter(attribute -> !attribute.isTransient())
             .forEach(attribute -> {
@@ -98,8 +100,13 @@ class EntityMetaGenerator extends EntityPartGenerator {
                     });
             }
             if (attribute.isEmbedded()) {
-                graph.embeddedDescriptorOf(attribute).ifPresent(embedded ->
-                    generateEmbedded(attribute, embedded, builder, targetName));
+                graph.embeddedDescriptorOf(attribute).ifPresent(embedded -> {
+                    generateEmbeddedAttributes(attribute, embedded, builder, targetName);
+                    if (!generatedEmbeddedTypes.contains(embedded.typeName())) {
+                        generatedEmbeddedTypes.add(embedded.typeName());
+                        generateEmbeddedEntity(embedded);
+                    }
+                });
             } else {
                 TypeMirror mirror = attribute.typeMirror();
                 builder.addField(
@@ -208,10 +215,10 @@ class EntityMetaGenerator extends EntityPartGenerator {
                         .build());
     }
 
-    private void generateEmbedded(AttributeDescriptor parent,
-                                  EntityDescriptor embedded,
-                                  TypeSpec.Builder builder,
-                                  TypeName targetName) {
+    private void generateEmbeddedAttributes(AttributeDescriptor parent,
+                                            EntityDescriptor embedded,
+                                            TypeSpec.Builder builder,
+                                            TypeName targetName) {
         // generate the embedded attributes into this type
         embedded.attributes().values().forEach(attribute -> {
             String fieldName = upperCaseUnderscoreRemovePrefixes(attribute.fieldName());
@@ -220,6 +227,9 @@ class EntityMetaGenerator extends EntityPartGenerator {
                 generateAttribute(attribute, parent, targetName, fieldName, mirror, false));
             attributeNames.add(fieldName);
         });
+    }
+
+    private void generateEmbeddedEntity(EntityDescriptor embedded) {
         // generate an embedded implementation for this (the parent) entity
         try {
             new EntityGenerator(processingEnv, graph, embedded, entity).generate();

--- a/requery-processor/src/main/java/io/requery/processor/EntityPartGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityPartGenerator.java
@@ -63,6 +63,12 @@ abstract class EntityPartGenerator {
         return "$" + attribute.fieldName();
     }
 
+    static String embeddedAttributeName(AttributeDescriptor parent,
+                                        AttributeDescriptor embedded) {
+        return Names.removeMemberPrefixes(parent.fieldName())
+                + "_"+ Names.removeMemberPrefixes(embedded.name());
+    }
+
     TypeName resolveAttributeType(AttributeDescriptor attribute) {
         TypeName typeName;
         if (attribute.isIterable()) {

--- a/requery-processor/src/main/java/io/requery/processor/EntityPartGenerator.java
+++ b/requery-processor/src/main/java/io/requery/processor/EntityPartGenerator.java
@@ -59,6 +59,25 @@ abstract class EntityPartGenerator {
         return "$" + attribute.fieldName() + "_state";
     }
 
+    static String attributeFieldName(AttributeDescriptor attribute) {
+        return "$" + attribute.fieldName();
+    }
+
+    TypeName resolveAttributeType(AttributeDescriptor attribute) {
+        TypeName typeName;
+        if (attribute.isIterable()) {
+            typeName = parameterizedCollectionName(attribute.typeMirror());
+        } else if (attribute.isOptional()) {
+            typeName = TypeName.get(tryFirstTypeArgument(attribute.typeMirror()));
+        } else {
+            typeName = nameResolver.generatedTypeNameOf(attribute.typeMirror()).orElse(null);
+        }
+        if (typeName == null) {
+            typeName = boxedTypeName(attribute.typeMirror());
+        }
+        return typeName;
+    }
+
     TypeName boxedTypeName(TypeMirror typeMirror) {
         if (typeMirror.getKind().isPrimitive()) {
             return TypeName.get(types.boxedClass((PrimitiveType) typeMirror).asType());


### PR DESCRIPTION
## How to solve

###  Fix duplicated entity generation
- `java.io.Writer(used in javapoet)` will throw exception when creating duplicated file
- `EntityMetaGenerator` tries to generate source file for each embedded attributes and doesn't consider multiple same type attributes.

Solution: record embedded types have already used to generate file

### Redesign embedded entity class
Old form
```
public class ParentEntity_ChildEntity extends Child implement Persistable {
    protected PropertyState $name_state;

    private final transient EntityProxy<TeamEntity> $proxy;

    public ParentEntity_ChildEntity(EntityProxy<TeamEntity> proxy) {
        this.$proxy = proxy;
    }

    public String getName() {
        return $proxy.get(package.ParentEntity.NAME);
    }

    public void setName(String name) {
        $proxy.set(package.ParentEntity.NAME, name);
    }
}
```

New form
```
public class ParentEntity_ChildEntity extends Child implement Persistable {
    protected PropertyState $name_state;

    // has attribute directly in embedded entity class
    private final Attribute<TeamEntity, String> $name; 

    private final transient EntityProxy<TeamEntity> $proxy;

    public ParentEntity_ChildEntity(EntityProxy<TeamEntity> proxy, Attribute<TeamEntity, String> name) {
        this.$proxy = proxy;
        this.$name = name; // initialize attribute in constructor
    }

    public String getName() {
        return $proxy.get($name);
    }

    public void setName(String name) {
        $proxy.set($name, name);
    }
}
```

### Separate attributes name space by prefixing embedded class name
When class has embedded member like a below
```
class abstract Parent {
    @Embedded
    Child jon;
}

@Embeddable
class Child {
    String name;
}
```

generated entity class has `name` attribute like a below
```
class ParentEntity implement Persistable {
    public static final Attribute<ParentEntity, String> JON_NAME = ...
}
```