### PR TITLE
partial selecting of properties

### DIFF
--- a/requery-kotlin/src/main/kotlin/io/requery/kotlin/Queryable.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/kotlin/Queryable.kt
@@ -57,6 +57,12 @@ inline operator fun <T : Persistable, reified E : T> Queryable<T>
     return select(*attributes.toTypedArray())
 }
 
+// selection only parts of object - returning data in Tuples
+inline fun <T : Persistable, reified E : T> Queryable<T>.selectPartial(vararg properties: KProperty1<E, *>): Selection<Result<Tuple>> {
+    val expressions: Array<Expression<*>> = Array(properties.size) { findAttribute(properties[it]) }
+    return select(*expressions)
+}
+
 interface QueryableAttribute<T, V> : Attribute<T, V>,
         Expression<V>,
         Functional<V>,

--- a/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/FunctionalTest.kt
+++ b/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/FunctionalTest.kt
@@ -82,7 +82,7 @@ class FunctionalTest {
     }
 
     @Test
-    fun testSelectPartial() {
+    fun testSelectObjectWithPartialProperties() {
         val person = randomPerson()
         data.invoke {
             insert(person)
@@ -90,6 +90,33 @@ class FunctionalTest {
             val result = data.select(Person::id, Person::name) limit 1
             val first = result().first()
             assertNotNull(first.name)
+        }
+    }
+
+    @Test
+    fun testSelectPartialWithOneColumn() {
+        val person = randomPerson()
+        data.invoke {
+            insert(person)
+            assertTrue(person.id > 0)
+            val result = data.selectPartial(Person::name) limit 1
+            val first = result().first()
+            assertNotNull(first[0])
+            assertEquals(1, first.count())
+        }
+    }
+
+    @Test
+    fun testSelectPartialWithTwoColumns() {
+        val person = randomPerson()
+        data.invoke {
+            insert(person)
+            assertTrue(person.id > 0)
+            val result = data.selectPartial(Person::name, Person::email) limit 1
+            val first = result().first()
+            assertNotNull(first[0])
+            assertNotNull(first[1])
+            assertEquals(2, first.count())
         }
     }
 


### PR DESCRIPTION
Tests method names (`testSelectPartial`) as well as method signatures (`fun(...).select(properties)`) suggest that using that method will cause only parts of object to be retrieved from db. However that's not the case in Kotlin support. Here `.select(properties)` always fetches full object. Also it is obligatory to provide in list of properties primary key of the table - otherwise crash will occur.

This implementation does what the name suggests - fetches only specified parts of object and returns it as a list of tuples.