### PR TITLE
Fixed generating fields with names forbidden in Java

### DIFF
--- a/requery-processor/src/main/java/io/requery/processor/AttributeMember.java
+++ b/requery-processor/src/main/java/io/requery/processor/AttributeMember.java
@@ -543,13 +543,15 @@ class AttributeMember extends BaseProcessableElement<Element> implements Attribu
             return element().getSimpleName().toString();
         } else if (element().getKind() == ElementKind.METHOD) {
             ExecutableElement methodElement = (ExecutableElement) element();
-            String name = methodElement.getSimpleName().toString();
+            String originalName = methodElement.getSimpleName().toString();
+            String name = originalName;
             name = Names.removeMethodPrefixes(name);
             if (Names.isAllUpper(name)) {
-                return name.toLowerCase(Locale.ROOT);
+                name = name.toLowerCase(Locale.ROOT);
             } else {
-                return Names.lowerCaseFirst(name);
+                name = Names.lowerCaseFirst(name);
             }
+            return Names.checkIfAttributeNameNotForbidden(name, originalName);
         } else {
             throw new IllegalStateException();
         }
@@ -617,6 +619,7 @@ class AttributeMember extends BaseProcessableElement<Element> implements Attribu
         // for a method strip any accessor prefix such as get/is
         if (element().getKind() == ElementKind.METHOD) {
             ExecutableElement executableElement = (ExecutableElement) element();
+            String originalName = elementName;
             AccessorNamePrefix prefix = AccessorNamePrefix.fromElement(executableElement);
             switch (prefix) {
                 case GET:
@@ -626,7 +629,8 @@ class AttributeMember extends BaseProcessableElement<Element> implements Attribu
                     elementName = elementName.replaceFirst("is", "");
                     break;
             }
-            return Names.isAllUpper(elementName) ? elementName : Names.lowerCaseFirst(elementName);
+            elementName = Names.isAllUpper(elementName) ? elementName : Names.lowerCaseFirst(elementName);
+            return Names.checkIfAttributeNameNotForbidden(elementName, originalName);
         }
         return elementName;
     }

--- a/requery-processor/src/main/java/io/requery/processor/Names.java
+++ b/requery-processor/src/main/java/io/requery/processor/Names.java
@@ -16,6 +16,8 @@
 
 package io.requery.processor;
 
+import javax.lang.model.SourceVersion;
+
 /**
  * Naming utility class.
  *
@@ -73,8 +75,7 @@ final class Names {
             return string.substring(1);
         }
         // detect mSomething names, which are common in Android apps
-        if (string.length() > 1 &&
-            string.startsWith("m") && Character.isUpperCase(string.charAt(1))) {
+        if (string.length() > 1 && string.startsWith("m") && Character.isUpperCase(string.charAt(1))) {
             return string.substring(1);
         }
         return string;
@@ -87,8 +88,7 @@ final class Names {
             return string.substring(3);
         }
         // isSomething() -> Something
-        if (string.startsWith("is") && string.length() > 2 &&
-            Character.isUpperCase(string.charAt(2))) {
+        if (string.startsWith("is") && string.length() > 2 && Character.isUpperCase(string.charAt(2))) {
             return string.substring(2);
         }
         return string;
@@ -103,5 +103,9 @@ final class Names {
             return typeName.replaceFirst("Base", "");
         }
         return typeName;
+    }
+
+    public static String checkIfAttributeNameNotForbidden(CharSequence newName, CharSequence fallback) {
+        return SourceVersion.isName(newName) ? newName.toString() : fallback.toString();
     }
 }

--- a/requery-test/kotlin-test/src/main/kotlin/io/requery/test/kt/Keywords.kt
+++ b/requery-test/kotlin-test/src/main/kotlin/io/requery/test/kt/Keywords.kt
@@ -1,0 +1,23 @@
+package io.requery.test.kt
+
+import io.requery.Entity
+import io.requery.Generated
+import io.requery.Key
+import io.requery.Persistable
+
+/**
+ * This class is a test itself.
+ * If project compilation succeeds, it means that forbidden names (e.g. java keywords) are processed properly.
+ */
+@Entity
+interface Keywords : Persistable {
+    @get:Key
+    @get:Generated
+    var id: Int
+
+    var isNotAJvmKeyword: String
+
+    var isNew: Boolean
+    var isDefault: String
+    var getAbstract: String
+}


### PR DESCRIPTION
Define an Entity class that has properties that could resolve to Java keywords fails code generation. For example
```
@Entity
interface Keywords : Persistable {
    @get:Key
    @get:Generated
    var id: Int

    var isDefault: Boolean
}
```
This class will have `isDefault` property resolved to private field: `private boolean default` which obviously can't compile.

I've added code that checks if new name is a proper Java name, if not, original name is returned.
Also I've tried to make it work in Java (there's similar problem), however I've failed to do so.
Hope you'll be able to fix it in Java as well.