### PR TITLE
allow returning null values as findByKey returns firstOrNull()

### DIFF
--- a/requery-kotlin/src/main/kotlin/io/requery/kotlin/EntityStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/kotlin/EntityStore.kt
@@ -40,7 +40,7 @@ interface EntityStore<T : Any, out R> : Queryable<T>, AutoCloseable {
     fun <E : T> refreshAll(entity: E): R
     infix fun <E : T> delete(entity: E): R
     infix fun <E : T> delete(entities: Iterable<E>): R
-    fun <E : T, K> findByKey(type: KClass<E>, key: K): R
+    fun <E : T, K> findByKey(type: KClass<E>, key: K): R?
     fun toBlocking(): BlockingEntityStore<T>
 }
 
@@ -60,7 +60,7 @@ interface BlockingEntityStore<T : Any> : EntityStore<T, Any> {
     override fun <E : T> refreshAll(entity: E): E
     override fun <E : T> delete(entity: E): Void
     override fun <E : T> delete(entities: Iterable<E>): Void
-    override fun <E : T, K> findByKey(type: KClass<E>, key: K): E
+    override fun <E : T, K> findByKey(type: KClass<E>, key: K): E?
 
     fun <V> withTransaction(body: BlockingEntityStore<T>.() -> V): V
     fun <V> withTransaction(isolation: TransactionIsolation, body: BlockingEntityStore<T>.() -> V): V

--- a/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
@@ -134,7 +134,7 @@ class KotlinEntityDataStore<T : Persistable>(configuration: Configuration) : Blo
     override fun <E : T> delete(entity: E): Void = data.delete(entity)
     override fun <E : T> delete(entities: Iterable<E>): Void = data.delete(entities)
 
-    override fun <E : T, K> findByKey(type: KClass<E>, key: K): E = data.findByKey(type.java, key)
+    override fun <E : T, K> findByKey(type: KClass<E>, key: K): E? = data.findByKey(type.java, key)
 
     override fun <V> withTransaction(body: BlockingEntityStore<T>.() -> V): V {
         try {


### PR DESCRIPTION
Now Kotlin intefaces expects non null objects from requery. Though 
`data.findByKey()` returns `firstOrNull()`. 