### PR TITLE
Removed `bindBlobLiteral' method, as there doesn't seem to be a need for it

### DIFF
--- a/requery-android/src/main/java/io/requery/android/sqlcipher/SqlCipherPreparedStatement.java
+++ b/requery-android/src/main/java/io/requery/android/sqlcipher/SqlCipherPreparedStatement.java
@@ -84,7 +84,7 @@ class SqlCipherPreparedStatement extends BasePreparedStatement {
         } else {
             statement.bindBlob(index, value);
             if (bindings != null) {
-                bindBlobLiteral(index, value);
+                bindings.add(value);
             }
         }
     }

--- a/requery-android/src/main/java/io/requery/android/sqlite/BasePreparedStatement.java
+++ b/requery-android/src/main/java/io/requery/android/sqlite/BasePreparedStatement.java
@@ -84,32 +84,6 @@ public abstract class BasePreparedStatement extends BaseStatement implements Pre
         return args;
     }
 
-    protected static String byteToHexString(byte[] bytes) {
-        StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for (byte b : bytes) {
-            sb.append(hex[(b >> 4) & 0xF]);
-            sb.append(hex[(b & 0xF)]);
-        }
-        return sb.toString();
-    }
-
-    // inlines a blob literal into the sql statement since it can't be used as bind parameter
-    protected void bindBlobLiteral(int index, byte[] value) {
-        int placeHolderIndex = 0;
-        int replace = 0;
-        for (int i = 0; i < sql.length(); i++) {
-            if (sql.charAt(i) == '?') {
-                placeHolderIndex++;
-                if (placeHolderIndex == index) {
-                    replace = i;
-                    break;
-                }
-            }
-        }
-        String literal = "x'" + byteToHexString(value) + "'";
-        sql = sql.substring(0, replace) + literal + sql.substring(replace + 1, sql.length());
-    }
-
     @Override
     public void addBatch() throws SQLException {
         throw new SQLFeatureNotSupportedException();

--- a/requery-android/src/main/java/io/requery/android/sqlite/SqlitePreparedStatement.java
+++ b/requery-android/src/main/java/io/requery/android/sqlite/SqlitePreparedStatement.java
@@ -80,7 +80,7 @@ class SqlitePreparedStatement extends BasePreparedStatement {
         } else {
             statement.bindBlob(index, value);
             if (bindings != null) {
-                bindBlobLiteral(index, value);
+                bindings.add(value);
             }
         }
     }

--- a/requery-android/src/main/java/io/requery/android/sqlitex/SqlitexPreparedStatement.java
+++ b/requery-android/src/main/java/io/requery/android/sqlitex/SqlitexPreparedStatement.java
@@ -81,7 +81,7 @@ class SqlitexPreparedStatement extends BasePreparedStatement {
         } else {
             statement.bindBlob(index, value);
             if (bindings != null) {
-                bindBlobLiteral(index, value);
+                bindings.add(value);
             }
         }
     }


### PR DESCRIPTION
When investigating #353, I noticed a complete lack of need for the `bindBlobLiteral` function - it manipulates the sql string `sql` that is entirely ignored by the program.