### PR TITLE
Fix NPE, allow to have fields different from relational in junction models

### DIFF
--- a/requery/src/main/java/io/requery/sql/EntityReader.java
+++ b/requery/src/main/java/io/requery/sql/EntityReader.java
@@ -314,10 +314,13 @@ class EntityReader<E extends S, S> implements PropertyLoader<E> {
                 QueryAttribute<Q, Object> uKey = null;
                 Type<?> junctionType = context.getModel().typeOf(attribute.getReferencedClass());
                 for (Attribute a : junctionType.getAttributes()) {
-                    if (type.getClassType().isAssignableFrom(a.getReferencedClass())) {
-                        tKey = Attributes.query(a);
-                    } else if (uType.isAssignableFrom(a.getReferencedClass())) {
-                        uKey = Attributes.query(a);
+                    Class referenceType = a.getReferencedClass();
+                    if (referenceType != null) {
+                        if (type.getClassType().isAssignableFrom(referenceType)) {
+                            tKey = Attributes.query(a);
+                        } else if (uType.isAssignableFrom(referenceType)) {
+                            uKey = Attributes.query(a);
+                        }
                     }
                 }
                 Objects.requireNotNull(tKey);


### PR DESCRIPTION
There was NPE happening with `@JunctionTable(type=MyRelationTable)` in case when some of fields was not references and `attribute.getReferencedClass()` returned null for them