### PR TITLE
QueryDelegate now conforms to DistinctSelection interface

### DIFF
--- a/requery-kotlin/src/main/kotlin/io/requery/kotlin/QueryDelegate.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/kotlin/QueryDelegate.kt
@@ -118,6 +118,7 @@ class JoinOnDelegate<E : Any>(element : JoinOnElement<E>, query : QueryDelegate<
 class QueryDelegate<E : Any>(element : QueryElement<E>) :
         Selectable<E>,
         Selection<E>,
+        DistinctSelection<E>,
         Insertion<E>,
         Update<E>,
         Deletion<E>,
@@ -199,7 +200,7 @@ class QueryDelegate<E : Any>(element : QueryElement<E>) :
 
     override fun distinct(): DistinctSelection<E> {
         element.distinct()
-        throw UnsupportedOperationException()
+        return this
     }
 
     override fun from(vararg types: KClass<out Any>): JoinWhereGroupByOrderBy<E> {


### PR DESCRIPTION
In Kotlin implementation of `QueryDelegate` function `distinct()` throws `UnsupportedOperationException` even though it is perfectly fine to perform `distinct` using delegation (similarly to all other implementations).
This PR follows the same convention as used throughout file to allow `distinct` to work.