### PR TITLE
Bugfix/illegal state exception null in rx java2

### DIFF
--- a/requery-kotlin/src/main/kotlin/io/requery/kotlin/EntityStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/kotlin/EntityStore.kt
@@ -38,8 +38,8 @@ interface EntityStore<T : Any, out R> : Queryable<T>, AutoCloseable {
     fun <E : T> refresh(entity: E, vararg attributes: Attribute<*, *>): R
     fun <E : T> refresh(entities: Iterable<E>, vararg attributes: Attribute<*, *>): R
     fun <E : T> refreshAll(entity: E): R
-    infix fun <E : T> delete(entity: E): R
-    infix fun <E : T> delete(entities: Iterable<E>): R
+    infix fun <E : T> delete(entity: E): R?
+    infix fun <E : T> delete(entities: Iterable<E>): R?
     fun <E : T, K> findByKey(type: KClass<E>, key: K): R?
     fun toBlocking(): BlockingEntityStore<T>
 }
@@ -58,8 +58,8 @@ interface BlockingEntityStore<T : Any> : EntityStore<T, Any> {
     override fun <E : T> refresh(entity: E, vararg attributes: Attribute<*, *>): E
     override fun <E : T> refresh(entities: Iterable<E>, vararg attributes: Attribute<*, *>): Iterable<E>
     override fun <E : T> refreshAll(entity: E): E
-    override fun <E : T> delete(entity: E): Void
-    override fun <E : T> delete(entities: Iterable<E>): Void
+    override fun <E : T> delete(entity: E): Void?
+    override fun <E : T> delete(entities: Iterable<E>): Void?
     override fun <E : T, K> findByKey(type: KClass<E>, key: K): E?
 
     fun <V> withTransaction(body: BlockingEntityStore<T>.() -> V): V

--- a/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
@@ -131,8 +131,8 @@ class KotlinEntityDataStore<T : Any>(configuration: Configuration) : BlockingEnt
             data.refresh(entities, *attributes)
     override fun <E : T> refreshAll(entity: E): E = data.refreshAll(entity)
 
-    override fun <E : T> delete(entity: E): Void = data.delete(entity)
-    override fun <E : T> delete(entities: Iterable<E>): Void = data.delete(entities)
+    override fun <E : T> delete(entity: E): Void? = data.delete(entity)
+    override fun <E : T> delete(entities: Iterable<E>): Void? = data.delete(entities)
 
     override fun <E : T, K> findByKey(type: KClass<E>, key: K): E? = data.findByKey(type.java, key)
 

--- a/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/ReactiveTest.kt
+++ b/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/ReactiveTest.kt
@@ -64,6 +64,20 @@ class ReactiveTest {
     }
 
     @Test
+    fun testGet() {
+        val person = randomPerson()
+        val personId = instance!!.insert(person).id
+
+        data.select(Person::class)
+                .where(Person::id.eq(personId))
+                .get()
+                .maybe()
+                .test()
+                .assertValue(person)
+                .assertComplete()
+    }
+
+    @Test
     fun testInsert() {
         val person = randomPerson()
         data.insert(person)


### PR DESCRIPTION
This PR is to make the Requery Kotlin extensions more suitable for Reactive streams in RxJava2.

The return type for `EntityStore.delete(entity: E)` was `Void`. The java implementor (EntityDataStore) returns a `null`. As nulls are forbidden in Reactive (RxJava2) streams this would cause the stream to throw an IllegalStateException.
The introduced fix makes the `Void` return type optional `Void?` which can be safely emitted in Reactive streams so the delete operation can complete without throwing the exception.

Boy scouting on the ReactiveTest.kt a bit as well