### PR TITLE
Resolve #425 UNIQUE constraint not placed on table uniqueIndexes

### DIFF
--- a/requery/src/main/java/io/requery/meta/ImmutableType.java
+++ b/requery/src/main/java/io/requery/meta/ImmutableType.java
@@ -34,6 +34,7 @@ final class ImmutableType<T> extends BaseType<T> {
         this.factory = builder.getFactory();
         this.proxyProvider = builder.getProxyProvider();
         this.tableCreateAttributes = builder.getTableCreateAttributes();
+        this.tableUniqueIndexes = builder.getTableUniqueIndexes();
         this.builderFactory = builder.getBuilderFactory();
         this.buildFunction = builder.getBuildFunction();
 


### PR DESCRIPTION
tableUniqueIndexes was being set on the TypeBuilder, but was not being set on the built ImmutableType.