### PR TITLE
Fix notification not sent in sub-transaction

### DIFF
--- a/requery/src/main/java/io/requery/sql/TransactionScope.java
+++ b/requery/src/main/java/io/requery/sql/TransactionScope.java
@@ -38,11 +38,12 @@ class TransactionScope implements AutoCloseable {
         if (!transaction.active()) {
             transaction.begin();
             enteredTransaction = true;
-            if (types != null) {
-                transaction.addToTransaction(types);
-            }
         } else {
             enteredTransaction = false;
+        }
+        
+        if (types != null) {
+            transaction.addToTransaction(types);
         }
     }
 


### PR DESCRIPTION
When a deletion is wrapped inside an active transaction, the notification for that deletion type is not sent out after transaction committed. The update was not affected tho, because updating goes though other path (`EntityDataStore.DataContenxt.proxyOf`) which adds the entity types to the transaction.