### PR TITLE
Added KotlinCompletableEntityStore

### DIFF
--- a/requery-kotlin/src/main/kotlin/io/requery/async/CompletableResult.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/async/CompletableResult.kt
@@ -1,0 +1,22 @@
+package io.requery.async
+
+import io.requery.query.Result
+import io.requery.query.ResultDelegate
+import io.requery.query.element.QueryElement
+import io.requery.query.element.QueryWrapper
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.function.Supplier
+
+class CompletableResult<E>(delegate: Result<E>, val executor: Executor) : ResultDelegate<E>(delegate), QueryWrapper<E> {
+
+    fun toCompletableFuture(): CompletableFuture<out Result<E>> = CompletableFuture.supplyAsync(Supplier { this }, executor)
+
+    inline fun <V> toCompletableFuture(crossinline block: CompletableResult<E>.() -> V): CompletableFuture<V>  {
+        return CompletableFuture.supplyAsync(Supplier { block() }, executor)
+    }
+
+    override fun unwrapQuery(): QueryElement<E> {
+        return (delegate as QueryWrapper<E>).unwrapQuery()
+    }
+}

--- a/requery-kotlin/src/main/kotlin/io/requery/async/CompletableScalar.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/async/CompletableScalar.kt
@@ -1,0 +1,11 @@
+package io.requery.async
+
+import io.requery.query.Scalar
+import io.requery.query.ScalarDelegate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+class CompletableScalar<E>(delegate: Scalar<E>, private val executor: Executor) : ScalarDelegate<E>(delegate) {
+
+    override fun toCompletableFuture(): CompletableFuture<E> = toCompletableFuture(executor)
+}

--- a/requery-kotlin/src/main/kotlin/io/requery/async/KotlinCompletableEntityStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/async/KotlinCompletableEntityStore.kt
@@ -1,0 +1,15 @@
+package io.requery.async
+
+import io.requery.kotlin.BlockingEntityStore
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.function.Supplier
+
+class KotlinCompletableEntityStore<T: Any>(private val store: BlockingEntityStore<T>,
+                                           val executor: Executor): BlockingEntityStore<T> by store {
+
+    inline fun <R> execute(crossinline block: BlockingEntityStore<T>.() -> R): CompletableFuture<R> {
+        return CompletableFuture.supplyAsync(Supplier { block() }, executor)
+    }
+
+}

--- a/requery-kotlin/src/main/kotlin/io/requery/async/KotlinCompletableEntityStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/async/KotlinCompletableEntityStore.kt
@@ -1,15 +1,83 @@
 package io.requery.async
 
-import io.requery.kotlin.BlockingEntityStore
+import io.requery.TransactionIsolation
+import io.requery.kotlin.*
+import io.requery.kotlin.Deletion
+import io.requery.kotlin.InsertInto
+import io.requery.kotlin.Insertion
+import io.requery.kotlin.Selection
+import io.requery.kotlin.Update
+import io.requery.meta.Attribute
+import io.requery.query.*
+import io.requery.util.function.Function
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.function.Supplier
+import kotlin.reflect.KClass
 
-class KotlinCompletableEntityStore<T: Any>(private val store: BlockingEntityStore<T>,
-                                           val executor: Executor): BlockingEntityStore<T> by store {
+class KotlinCompletableEntityStore<T : Any>(private val store: BlockingEntityStore<T>,
+                                            val executor: Executor) : EntityStore<T, Any> {
 
-    inline fun <R> execute(crossinline block: BlockingEntityStore<T>.() -> R): CompletableFuture<R> {
+    override fun close() = store.close()
+
+    override infix fun <E : T> select(type: KClass<E>): Selection<CompletableResult<E>> = result(store.select(type))
+    override fun <E : T> select(type: KClass<E>, vararg attributes: QueryableAttribute<E, *>): Selection<CompletableResult<E>> = result(store.select(type, *attributes))
+    override fun select(vararg expressions: Expression<*>): Selection<CompletableResult<Tuple>> = result(store.select(*expressions))
+
+    override fun <E : T> insert(type: KClass<E>): Insertion<CompletableResult<Tuple>> = result(store.insert(type))
+    override fun <E : T> insert(type: KClass<E>, vararg attributes: QueryableAttribute<E, *>): InsertInto<out Result<Tuple>> = result(store.insert(type, *attributes))
+    override fun update(): Update<CompletableScalar<Int>> = scalar(store.update())
+    override fun <E : T> update(type: KClass<E>): Update<CompletableScalar<Int>> = scalar(store.update(type))
+
+    override fun delete(): Deletion<CompletableScalar<Int>> = scalar(store.delete())
+    override fun <E : T> delete(type: KClass<E>): Deletion<CompletableScalar<Int>> = scalar(store.delete(type))
+
+    override fun <E : T> count(type: KClass<E>): Selection<CompletableScalar<Int>> = scalar(store.count(type))
+    override fun count(vararg attributes: QueryableAttribute<T, *>): Selection<CompletableScalar<Int>> = scalar(store.count(*attributes))
+
+    override fun <E : T> insert(entity: E): CompletableFuture<E> = execute { store.insert(entity) }
+    override fun <E : T> insert(entities: Iterable<E>): CompletableFuture<Iterable<E>> = execute { store.insert(entities) }
+    override fun <K : Any, E : T> insert(entity: E, keyClass: KClass<K>): CompletableFuture<K> = execute { store.insert(entity, keyClass) }
+    override fun <K : Any, E : T> insert(entities: Iterable<E>, keyClass: KClass<K>): CompletableFuture<Iterable<K>> = execute { store.insert(entities, keyClass) }
+
+    override fun <E : T> update(entity: E): CompletableFuture<E> = execute { store.update(entity) }
+    override fun <E : T> update(entities: Iterable<E>): CompletableFuture<Iterable<E>> = execute { store.update(entities) }
+
+    override fun <E : T> upsert(entity: E): CompletableFuture<E> = execute { store.upsert(entity) }
+    override fun <E : T> upsert(entities: Iterable<E>): CompletableFuture<Iterable<E>> = execute { store.upsert(entities) }
+
+    override fun <E : T> refresh(entity: E): CompletableFuture<E> = execute { store.refresh(entity) }
+    override fun <E : T> refresh(entity: E, vararg attributes: Attribute<*, *>): CompletableFuture<E> = execute { store.refresh(entity, *attributes) }
+
+    override fun <E : T> refresh(entities: Iterable<E>, vararg attributes: Attribute<*, *>): CompletableFuture<Iterable<E>> = execute { store.refresh(entities, *attributes) }
+    override fun <E : T> refreshAll(entity: E): CompletableFuture<E> = execute { store.refreshAll(entity) }
+
+    override fun <E : T> delete(entity: E): CompletableFuture<*> = execute { store.delete(entity) }
+    override fun <E : T> delete(entities: Iterable<E>): CompletableFuture<*> = execute { store.delete(entities) }
+
+    override fun raw(query: String, vararg parameters: Any): Result<Tuple> = store.raw(query, parameters)
+    override fun <E : T> raw(type: KClass<E>, query: String, vararg parameters: Any): Result<E> = store.raw(type, query, parameters)
+
+    override fun <E : T, K> findByKey(type: KClass<E>, key: K): CompletableFuture<E?> = execute { store.findByKey(type, key) }
+
+    override fun toBlocking(): BlockingEntityStore<T> = store
+
+    fun <V> withTransaction(body: BlockingEntityStore<T>.() -> V): CompletableFuture<V> = execute { store.withTransaction(body) }
+    fun <V> withTransaction(isolation: TransactionIsolation, body: BlockingEntityStore<T>.() -> V): CompletableFuture<V> = execute { store.withTransaction(isolation, body) }
+    
+    inline fun <V> execute(crossinline block: KotlinCompletableEntityStore<T>.() -> V): CompletableFuture<V> {
         return CompletableFuture.supplyAsync(Supplier { block() }, executor)
     }
 
+    @Suppress("UNCHECKED_CAST")
+    private fun <E> result(query: Return<out Result<E>>): QueryDelegate<CompletableResult<E>> {
+        val element = query as QueryDelegate<Result<E>>
+        return element.extend(Function { result -> CompletableResult(result, executor) })
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <E> scalar(query: Return<out Scalar<E>>): QueryDelegate<CompletableScalar<E>> {
+        val element = query as QueryDelegate<Scalar<E>>
+        return element.extend(Function { result -> CompletableScalar(result, executor) })
+    }
 }

--- a/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2017 requery.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
+++ b/requery-kotlin/src/main/kotlin/io/requery/sql/KotlinEntityDataStore.kt
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright 2017 requery.io
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/CompletableTest.kt
+++ b/requery-test/kotlin-test/src/test/kotlin/io/requery/test/kt/CompletableTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 requery.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.requery.test.kt
+
+import io.requery.async.KotlinCompletableEntityStore
+import io.requery.kotlin.eq
+import io.requery.kotlin.invoke
+import io.requery.sql.KotlinConfiguration
+import io.requery.sql.KotlinEntityDataStore
+import io.requery.sql.SchemaModifier
+import io.requery.sql.TableCreationMode
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.sql.SQLException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import kotlin.properties.Delegates
+
+class CompletableTest {
+
+    val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    var instance: KotlinEntityDataStore<Any> by Delegates.notNull()
+    val data: KotlinCompletableEntityStore<Any> get() = KotlinCompletableEntityStore(instance, executor)
+
+    internal fun randomPerson(): Person {
+        return FunctionalTest.randomPerson()
+    }
+
+    @Before
+    @Throws(SQLException::class)
+    fun setup() {
+        val model = Models.KT
+        val dataSource = JdbcDataSource()
+        dataSource.setUrl("jdbc:h2:~/testh2")
+        dataSource.user = "sa"
+        dataSource.password = "sa"
+
+        val configuration = KotlinConfiguration(
+                dataSource = dataSource,
+                model = model,
+                statementCacheSize = 0,
+                useDefaultLogging = true)
+        instance = KotlinEntityDataStore(configuration)
+        val tables = SchemaModifier(configuration)
+        tables.dropTables()
+        val mode = TableCreationMode.CREATE
+        tables.createTables(mode)
+    }
+
+    @After
+    fun teardown() {
+        data.close()
+    }
+
+    @Test
+    fun testInsert() {
+        val person = FunctionalTest.randomPerson()
+        val insertedPerson = data.execute {
+            insert(person)
+        }.get()
+
+        assertTrue(insertedPerson.id > 0)
+        data.invoke {
+            val result = select(Person::class) where (Person::id eq person.id) limit 10
+            assertSame(result().first(), person)
+        }
+    }
+
+
+    @Test
+    fun testGet() {
+        val person = randomPerson()
+        val personId = instance.insert(person).id
+
+        val returnedPerson = data.execute {
+            select(Person::class)
+                    .where(Person::id.eq(personId))
+                    .get()
+                    .first()
+        }.get()
+        assertEquals(person, returnedPerson)
+    }
+}


### PR DESCRIPTION
#583 

The main idea is to hide the executor being used.

This will allow projects that use DI to configure the entity store with the right Executor that should be used for IO operations.

## Usage
```kotlin
data.execute {
    select(Person::class)
       .where(Person::id.eq(personId))
       .get()
       .first()
}
```

@npurushe Let me know if there is anything else that should be done