### PR TITLE
Resolve #651 Insert should not cascade if CascadeAction.SAVE is not s…

### DIFF
--- a/requery-test/src/main/java/io/requery/test/FunctionalTest.java
+++ b/requery-test/src/main/java/io/requery/test/FunctionalTest.java
@@ -37,9 +37,11 @@ import io.requery.query.function.Random;
 import io.requery.query.function.Upper;
 import io.requery.sql.EntityDataStore;
 import io.requery.test.model.Address;
+import io.requery.test.model.Child;
 import io.requery.test.model.Group;
 import io.requery.test.model.GroupType;
 import io.requery.test.model.Group_Person;
+import io.requery.test.model.Parent;
 import io.requery.test.model.Person;
 import io.requery.test.model.Phone;
 import io.requery.util.function.Consumer;
@@ -1561,4 +1563,16 @@ public abstract class FunctionalTest extends RandomData {
         data.insert(p2);
         fail();
     }
+
+    @Test(expected = PersistenceException.class)
+    public void testInsertWithoutCascadeActionSave() {
+        Child child = new Child();
+        child.setId(1);
+        Parent parent = new Parent();
+        parent.setChild(child);
+
+        // This violates the Foreign Key Constraint, because Child does not exist and CascadeAction.SAVE is not specified
+        data.insert(parent);
+    }
+
 }

--- a/requery-test/src/main/java/io/requery/test/jpa/Person.java
+++ b/requery-test/src/main/java/io/requery/test/jpa/Person.java
@@ -49,7 +49,7 @@ public interface Person extends Serializable {
     @Column(nullable = true)
     int getAge();
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(foreignKey = @ForeignKey)
     Address getAddress();
 

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChild.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChild.java
@@ -1,0 +1,16 @@
+package io.requery.test.model;
+
+import io.requery.Entity;
+import io.requery.Key;
+
+/**
+ * Created by mluchi on 04/08/2017.
+ */
+
+@Entity
+public abstract class AbstractChild {
+
+    @Key
+    long id;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractParent.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractParent.java
@@ -1,0 +1,26 @@
+package io.requery.test.model;
+
+import io.requery.CascadeAction;
+import io.requery.Entity;
+import io.requery.ForeignKey;
+import io.requery.Generated;
+import io.requery.Key;
+import io.requery.ManyToOne;
+import io.requery.ReferentialAction;
+
+/**
+ * Created by mluchi on 04/08/2017.
+ */
+
+@Entity
+public abstract class AbstractParent {
+
+    @Key
+    @Generated
+    long id;
+
+    @ManyToOne(cascade = CascadeAction.DELETE)
+    @ForeignKey(delete = ReferentialAction.SET_NULL, update = ReferentialAction.RESTRICT)
+    AbstractChild child;
+
+}

--- a/requery-test/src/test/java/io/requery/test/DatabaseType.java
+++ b/requery-test/src/test/java/io/requery/test/DatabaseType.java
@@ -80,11 +80,9 @@ public enum DatabaseType {
             SQLiteConfig config = new SQLiteConfig();
             config.setDateClass("TEXT");
             dataSource.setConfig(config);
-            try (Statement statement = dataSource.getConnection().createStatement()) {
-                statement.execute("PRAGMA foreign_keys = ON");
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
+            // Turn on foreign keys support.
+            // NOTE: Do it after setConfig, or setConfig will overwrite this setting
+            dataSource.setEnforceForeinKeys(true);
             return dataSource;
         }
     },

--- a/requery/src/main/java/io/requery/sql/EntityWriter.java
+++ b/requery/src/main/java/io/requery/sql/EntityWriter.java
@@ -442,7 +442,9 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
 
         for (Attribute<E, ?> attribute : associativeAttributes) {
             // persist the foreign key object if needed
-            cascadeKeyReference(Cascade.INSERT, proxy, attribute);
+            if(attribute.getCascadeActions().contains(CascadeAction.SAVE)) {
+                cascadeKeyReference(Cascade.INSERT, proxy, attribute);
+            }
         }
         incrementVersion(proxy);
         for (Attribute<E, ?> attribute : bindableAttributes) {


### PR DESCRIPTION
…pecified

Modify EntityWriter.insert method to cascade insertion on emtities referenced by foreign key ONLY when CascadeAction.SAVE is specified