### PR TITLE
Resolve #685 One-to-Many and Many-to-Many associations are not saved …

### DIFF
--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToManyNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToManyNoCascade.java
@@ -1,9 +1,13 @@
 package io.requery.test.model;
 
 
+import java.util.List;
+
+import io.requery.CascadeAction;
 import io.requery.Column;
 import io.requery.Entity;
 import io.requery.Key;
+import io.requery.ManyToMany;
 
 /**
  * Created by mluchi on 03/08/2017.
@@ -16,5 +20,8 @@ public abstract class AbstractChildManyToManyNoCascade {
 
     @Column
     String attribute;
+
+    @ManyToMany(mappedBy = "manyToMany", cascade = CascadeAction.NONE)
+    List<ParentNoCascade> parents;
 
 }

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToManyNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToManyNoCascade.java
@@ -1,0 +1,20 @@
+package io.requery.test.model;
+
+
+import io.requery.Column;
+import io.requery.Entity;
+import io.requery.Key;
+
+/**
+ * Created by mluchi on 03/08/2017.
+ */
+@Entity(cacheable = false)
+public abstract class AbstractChildManyToManyNoCascade {
+
+    @Key
+    long id;
+
+    @Column
+    String attribute;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToOneNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildManyToOneNoCascade.java
@@ -1,0 +1,20 @@
+package io.requery.test.model;
+
+
+import io.requery.Column;
+import io.requery.Entity;
+import io.requery.Key;
+
+/**
+ * Created by mluchi on 03/08/2017.
+ */
+@Entity(cacheable = false)
+public abstract class AbstractChildManyToOneNoCascade {
+
+    @Key
+    long id;
+
+    @Column
+    String attribute;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToManyNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToManyNoCascade.java
@@ -22,7 +22,7 @@ public abstract class AbstractChildOneToManyNoCascade {
     String attribute;
 
     @ManyToOne(cascade = CascadeAction.NONE)
-    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    @ForeignKey(update = ReferentialAction.RESTRICT, delete = ReferentialAction.SET_NULL)
     ParentNoCascade parent;
 
 }

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToManyNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToManyNoCascade.java
@@ -1,0 +1,28 @@
+package io.requery.test.model;
+
+
+import io.requery.CascadeAction;
+import io.requery.Column;
+import io.requery.Entity;
+import io.requery.ForeignKey;
+import io.requery.Key;
+import io.requery.ManyToOne;
+import io.requery.ReferentialAction;
+
+/**
+ * Created by mluchi on 03/08/2017.
+ */
+@Entity(cacheable = false)
+public abstract class AbstractChildOneToManyNoCascade {
+
+    @Key
+    long id;
+
+    @Column
+    String attribute;
+
+    @ManyToOne(cascade = CascadeAction.NONE)
+    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    ParentNoCascade parent;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToOneNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractChildOneToOneNoCascade.java
@@ -1,0 +1,20 @@
+package io.requery.test.model;
+
+
+import io.requery.Column;
+import io.requery.Entity;
+import io.requery.Key;
+
+/**
+ * Created by mluchi on 03/08/2017.
+ */
+@Entity(cacheable = false)
+public abstract class AbstractChildOneToOneNoCascade {
+
+    @Key
+    long id;
+
+    @Column
+    String attribute;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractParentNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractParentNoCascade.java
@@ -1,0 +1,43 @@
+package io.requery.test.model;
+
+
+import java.util.List;
+
+import io.requery.CascadeAction;
+import io.requery.Entity;
+import io.requery.ForeignKey;
+import io.requery.JunctionTable;
+import io.requery.Key;
+import io.requery.ManyToMany;
+import io.requery.ManyToOne;
+import io.requery.OneToMany;
+import io.requery.OneToOne;
+import io.requery.ReferentialAction;
+
+
+/**
+ * Created by mluchi on 03/08/2017.
+ */
+
+@Entity(cacheable = false)
+public abstract class AbstractParentNoCascade {
+
+    @Key
+    long id;
+
+    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    @OneToOne(cascade = {CascadeAction.NONE})
+    ChildOneToOneNoCascade oneToOne;
+
+    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    @ManyToOne(cascade = {CascadeAction.NONE})
+    ChildManyToOneNoCascade manyToOne;
+
+    @OneToMany(cascade = {CascadeAction.NONE})
+    List<ChildOneToManyNoCascade> oneToMany;
+
+    @ManyToMany(cascade = {CascadeAction.NONE})
+    @JunctionTable
+    List<ChildManyToManyNoCascade> manyToMany;
+
+}

--- a/requery-test/src/main/java/io/requery/test/model/AbstractParentNoCascade.java
+++ b/requery-test/src/main/java/io/requery/test/model/AbstractParentNoCascade.java
@@ -25,11 +25,11 @@ public abstract class AbstractParentNoCascade {
     @Key
     long id;
 
-    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    @ForeignKey(delete = ReferentialAction.SET_NULL, update = ReferentialAction.RESTRICT)
     @OneToOne(cascade = {CascadeAction.NONE})
     ChildOneToOneNoCascade oneToOne;
 
-    @ForeignKey(delete = ReferentialAction.SET_NULL)
+    @ForeignKey(delete = ReferentialAction.SET_NULL, update = ReferentialAction.RESTRICT)
     @ManyToOne(cascade = {CascadeAction.NONE})
     ChildManyToOneNoCascade manyToOne;
 

--- a/requery/src/main/java/io/requery/sql/platform/Derby.java
+++ b/requery/src/main/java/io/requery/sql/platform/Derby.java
@@ -96,4 +96,10 @@ public class Derby extends Generic {
     public boolean supportsUpsert() {
         return true;
     }
+
+    @Override
+    public boolean supportsOnUpdateCascade() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
…if CascadeAction.NONE is present

Fix EntityWriter to process all associations (event if they have CascadeAction.NONE), because it might have just to create the association between parent and child
Fix cascading of update operation to fail if nothing was updated.