### PR TITLE
Fix types conversion with custom converters for aliased expressions

### DIFF
--- a/requery/src/main/java/io/requery/sql/GenericMapping.java
+++ b/requery/src/main/java/io/requery/sql/GenericMapping.java
@@ -283,6 +283,12 @@ public class GenericMapping implements Mapping {
             converter = attribute.getConverter();
             type = attribute.getClassType();
             fieldType = mapAttribute(attribute);
+        } else if (expression.getExpressionType() == ExpressionType.ALIAS) {
+            @SuppressWarnings("unchecked")
+            Attribute<?, A> attribute = (Attribute) expression.getInnerExpression();
+            converter = attribute.getConverter();
+            type = attribute.getClassType();
+            fieldType = mapAttribute(attribute);
         } else {
             type = expression.getClassType();
             fieldType = getSubstitutedType(type);


### PR DESCRIPTION
Currently requery fails to see custom converters with queries like:
`dataStore.select(Entity.LENGTH.as("item_length")...)` and tries to use String as data type.
This pull request fixes that behaviour.