### PR TITLE
Use name() instead of toString() in EnumStringConverter.

### DIFF
--- a/requery-test/src/test/java/io/requery/test/AbstractConverterTest.java
+++ b/requery-test/src/test/java/io/requery/test/AbstractConverterTest.java
@@ -44,11 +44,13 @@ public abstract class AbstractConverterTest<T extends Converter<FROM, TO>, FROM,
         org.junit.Assert.assertTrue("Test cases map does not have unique values!", testCases.size() == getTestCases().size());
         for (TO from : testCases.keySet()) {
             FROM expectedConvertedValue = testCases.get(from);
-            FROM convertedValue = getConverter().convertToMapped(null, from);
+            FROM convertedValue = getConverter().convertToMapped(getType(), from);
 
             assertEquals(expectedConvertedValue, convertedValue);
         }
     }
+
+    protected abstract Class<? extends FROM> getType();
 
     protected void assertEquals(Object obj1, Object obj2) {
         org.junit.Assert.assertEquals(obj1, obj2);

--- a/requery-test/src/test/java/io/requery/test/CurrencyConverterTest.java
+++ b/requery-test/src/test/java/io/requery/test/CurrencyConverterTest.java
@@ -30,4 +30,9 @@ public class CurrencyConverterTest extends AbstractConverterTest<CurrencyConvert
         return testCases;
     }
 
+    @Override
+    protected Class<? extends Currency> getType() {
+        return null;
+    }
+
 }

--- a/requery-test/src/test/java/io/requery/test/EnumStringConverterTest.java
+++ b/requery-test/src/test/java/io/requery/test/EnumStringConverterTest.java
@@ -1,0 +1,41 @@
+package io.requery.test;
+
+import io.requery.converter.EnumStringConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by DennisHartrampf on 01/03/2018.
+ */
+public class EnumStringConverterTest extends AbstractConverterTest<EnumStringConverter<EnumStringConverterTest.TestEnum>, EnumStringConverterTest.TestEnum, String> {
+
+    enum TestEnum {
+        CONSTANT_1, CONSTANT_2;
+
+        @Override
+        public String toString() {
+            return "I cannot be used for persistence";
+        }
+    }
+
+    @Override
+    public EnumStringConverter<EnumStringConverterTest.TestEnum> getConverter() {
+        return new EnumStringConverter<>(TestEnum.class);
+    }
+
+    @Override
+    public Map<TestEnum, String> getTestCases() {
+        Map<TestEnum, String> testCases = new HashMap<>();
+        testCases.put(TestEnum.CONSTANT_1, "CONSTANT_1");
+        testCases.put(TestEnum.CONSTANT_2, "CONSTANT_2");
+        testCases.put(null, null);
+        return testCases;
+    }
+
+    @Override
+    protected Class<? extends TestEnum> getType() {
+        return TestEnum.class;
+    }
+
+}

--- a/requery/src/main/java/io/requery/converter/EnumStringConverter.java
+++ b/requery/src/main/java/io/requery/converter/EnumStringConverter.java
@@ -19,7 +19,7 @@ package io.requery.converter;
 import io.requery.Converter;
 
 /**
- * Converter which persists an {@link Enum} using its {@link Enum#toString()} representation.
+ * Converter which persists an {@link Enum} using its {@link Enum#name()} representation.
  *
  * @param <E> type of enum
  */
@@ -48,7 +48,7 @@ public class EnumStringConverter<E extends Enum> implements Converter<E, String>
 
     @Override
     public String convertToPersisted(Enum value) {
-        return value == null ? null : value.toString();
+        return value == null ? null : value.name();
     }
 
     @Override


### PR DESCRIPTION
This PR is a proposal to fix #755 . It is my first contribution and I tried to follow the contribution guidelines. Please be kind if I missed something ;)