### PR TITLE
Add entity name to RowCountException

### DIFF
--- a/requery/src/main/java/io/requery/sql/EntityWriter.java
+++ b/requery/src/main/java/io/requery/sql/EntityWriter.java
@@ -178,7 +178,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
         if (proxy != null && versionAttribute != null && count == 0) {
             throw new OptimisticLockException(entity, proxy.get(versionAttribute));
         } else if (count != 1) {
-            throw new RowCountException(1, count);
+            throw new RowCountException(entity.getClass().getName(), 1, count);
         }
     }
 
@@ -505,7 +505,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                 }
                 int rows = upsert.evaluate(element).value();
                 if (rows <= 0) {
-                    throw new RowCountException(1, rows);
+                    throw new RowCountException(entity.getClass().getName(), 1, rows);
                 }
                 proxy.link(context.read(entityClass));
                 updateAssociations(Cascade.UPSERT, entity, proxy, null);
@@ -773,7 +773,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                                 .and(uKey.equal(otherValue));
                         int count = query.get().value();
                         if (count != 1) {
-                            throw new RowCountException(1, count);
+                            throw new RowCountException(entity.getClass().getName(), 1, count);
                         }
                     }
                     changes.clear();
@@ -953,7 +953,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                         // If this happens, it means that I'm updating the 'many' side of a
                         // one-to-many (where the foreign key is) to link it to the 'one' side of
                         // the relationship, but the 'many' side does not exist.
-                        throw new RowCountException(1, updated);
+                        throw new RowCountException(entity.getClass().getName(), 1, updated);
                     }
                     break;
                 case UPSERT:
@@ -1022,7 +1022,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                 }
                 int rows = deletion.get().value();
                 if (rows != ids.size()) {
-                    throw new RowCountException(ids.size(), rows);
+                    throw new RowCountException(entityClass.getSimpleName(), ids.size(), rows);
                 }
             }
         }

--- a/requery/src/main/java/io/requery/sql/EntityWriter.java
+++ b/requery/src/main/java/io/requery/sql/EntityWriter.java
@@ -178,7 +178,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
         if (proxy != null && versionAttribute != null && count == 0) {
             throw new OptimisticLockException(entity, proxy.get(versionAttribute));
         } else if (count != 1) {
-            throw new RowCountException(entity.getClass().getName(), 1, count);
+            throw new RowCountException(entity.getClass(), 1, count);
         }
     }
 
@@ -505,7 +505,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                 }
                 int rows = upsert.evaluate(element).value();
                 if (rows <= 0) {
-                    throw new RowCountException(entity.getClass().getName(), 1, rows);
+                    throw new RowCountException(entity.getClass(), 1, rows);
                 }
                 proxy.link(context.read(entityClass));
                 updateAssociations(Cascade.UPSERT, entity, proxy, null);
@@ -773,7 +773,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                                 .and(uKey.equal(otherValue));
                         int count = query.get().value();
                         if (count != 1) {
-                            throw new RowCountException(entity.getClass().getName(), 1, count);
+                            throw new RowCountException(entity.getClass(), 1, count);
                         }
                     }
                     changes.clear();
@@ -953,7 +953,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                         // If this happens, it means that I'm updating the 'many' side of a
                         // one-to-many (where the foreign key is) to link it to the 'one' side of
                         // the relationship, but the 'many' side does not exist.
-                        throw new RowCountException(entity.getClass().getName(), 1, updated);
+                        throw new RowCountException(entity.getClass(), 1, updated);
                     }
                     break;
                 case UPSERT:
@@ -1022,7 +1022,7 @@ class EntityWriter<E extends S, S> implements ParameterBinder<E> {
                 }
                 int rows = deletion.get().value();
                 if (rows != ids.size()) {
-                    throw new RowCountException(entityClass.getSimpleName(), ids.size(), rows);
+                    throw new RowCountException(entityClass, ids.size(), rows);
                 }
             }
         }

--- a/requery/src/main/java/io/requery/sql/RowCountException.java
+++ b/requery/src/main/java/io/requery/sql/RowCountException.java
@@ -18,19 +18,22 @@ package io.requery.sql;
 
 import io.requery.PersistenceException;
 
+import javax.annotation.Nonnull;
+
 /**
  * Exception thrown when the affected row count of a executed statement doesn't match the value
  * expected.
  */
 public class RowCountException extends PersistenceException {
 
-    private final String entityName;
+    @Nonnull
+    private final Class<?> entityClass;
     private final long expected;
     private final long actual;
 
-    RowCountException(String entityName, long expected, long actual) {
-        super(entityName + ": expected " + expected + " row affected actual " + actual);
-        this.entityName = entityName;
+    RowCountException(@Nonnull Class<?> entityClass, long expected, long actual) {
+        super(entityClass.getSimpleName() + ": expected " + expected + " row affected actual " + actual);
+        this.entityClass = entityClass;
         this.expected = expected;
         this.actual = actual;
     }
@@ -50,9 +53,10 @@ public class RowCountException extends PersistenceException {
     }
 
     /**
-     * @return entity name affected
+     * @return entity class affected
      */
-    public String getEntityName() {
-        return entityName;
+    @Nonnull
+    public Class<?> getEntityClass() {
+        return entityClass;
     }
 }

--- a/requery/src/main/java/io/requery/sql/RowCountException.java
+++ b/requery/src/main/java/io/requery/sql/RowCountException.java
@@ -24,11 +24,13 @@ import io.requery.PersistenceException;
  */
 public class RowCountException extends PersistenceException {
 
+    private final String entityName;
     private final long expected;
     private final long actual;
 
-    RowCountException(long expected, long actual) {
-        super("Expected " + expected + " row affected actual " + actual);
+    RowCountException(String entityName, long expected, long actual) {
+        super(entityName + ": expected " + expected + " row affected actual " + actual);
+        this.entityName = entityName;
         this.expected = expected;
         this.actual = actual;
     }
@@ -45,5 +47,12 @@ public class RowCountException extends PersistenceException {
      */
     public long getActual() {
         return actual;
+    }
+
+    /**
+     * @return entity name affected
+     */
+    public String getEntityName() {
+        return entityName;
     }
 }


### PR DESCRIPTION
I see `RowCountException` sometimes in the Crashlytics logs, but its message doesn't say which entity failed (and there is no root SQLException, which would say this), so the goal of this PR is to add failed entity name to the exception message.

I also didn't fine any way to test throwing this exception, do you have any advice on that?