### PR TITLE
Add getInsertGenerator, getUpdateGenerator to Platform interface 

### DIFF
--- a/requery/src/main/java/io/requery/sql/Platform.java
+++ b/requery/src/main/java/io/requery/sql/Platform.java
@@ -19,6 +19,7 @@ package io.requery.sql;
 import io.requery.query.Expression;
 import io.requery.query.element.LimitedElement;
 import io.requery.query.element.OrderByElement;
+import io.requery.query.element.QueryElement;
 import io.requery.sql.gen.Generator;
 
 import java.util.Map;
@@ -89,6 +90,16 @@ public interface Platform {
      * @return the limit generator for this database
      */
     Generator<LimitedElement> limitGenerator();
+
+    /**
+     * @return the insert generator for this database
+     */
+    Generator<QueryElement<?>> insertGenerator();
+
+    /**
+     * @return the update generator for this database
+     */
+    Generator<Map<Expression<?>, Object>> updateGenerator();
 
     /**
      * @return the upsert generator for this database

--- a/requery/src/main/java/io/requery/sql/gen/InsertGenerator.java
+++ b/requery/src/main/java/io/requery/sql/gen/InsertGenerator.java
@@ -29,7 +29,7 @@ import static io.requery.sql.Keyword.INSERT;
 import static io.requery.sql.Keyword.INTO;
 import static io.requery.sql.Keyword.VALUES;
 
-class InsertGenerator implements Generator<QueryElement<?>> {
+public class InsertGenerator implements Generator<QueryElement<?>> {
 
     @Override
     public void write(final Output output, QueryElement<?> query) {

--- a/requery/src/main/java/io/requery/sql/gen/StatementGenerator.java
+++ b/requery/src/main/java/io/requery/sql/gen/StatementGenerator.java
@@ -48,8 +48,8 @@ public final class StatementGenerator implements Generator<QueryElement<?>> {
     public StatementGenerator(Platform platform) {
         // TODO eventually all parts will be overridable
         select = new SelectGenerator();
-        insert = new InsertGenerator();
-        update = new UpdateGenerator();
+        insert = platform.insertGenerator();
+        update = platform.updateGenerator();
         upsert = platform.upsertGenerator();
         where = new WhereGenerator();
         groupBy = new GroupByGenerator();

--- a/requery/src/main/java/io/requery/sql/gen/UpdateGenerator.java
+++ b/requery/src/main/java/io/requery/sql/gen/UpdateGenerator.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import static io.requery.sql.Keyword.SET;
 import static io.requery.sql.Keyword.UPDATE;
 
-class UpdateGenerator implements Generator<Map<Expression<?>, Object>> {
+public class UpdateGenerator implements Generator<Map<Expression<?>, Object>> {
 
     @Override
     public void write(final Output output, Map<Expression<?>, Object> values) {

--- a/requery/src/main/java/io/requery/sql/platform/Generic.java
+++ b/requery/src/main/java/io/requery/sql/platform/Generic.java
@@ -20,8 +20,6 @@ import io.requery.query.Expression;
 import io.requery.query.element.LimitedElement;
 import io.requery.query.element.OrderByElement;
 import io.requery.query.element.QueryElement;
-import io.requery.sql.*;
-import io.requery.sql.gen.*;
 
 import java.util.Map;
 

--- a/requery/src/main/java/io/requery/sql/platform/Generic.java
+++ b/requery/src/main/java/io/requery/sql/platform/Generic.java
@@ -19,17 +19,9 @@ package io.requery.sql.platform;
 import io.requery.query.Expression;
 import io.requery.query.element.LimitedElement;
 import io.requery.query.element.OrderByElement;
-import io.requery.sql.GeneratedColumnDefinition;
-import io.requery.sql.IdentityColumnDefinition;
-import io.requery.sql.Mapping;
-import io.requery.sql.Platform;
-import io.requery.sql.UserVersionColumnDefinition;
-import io.requery.sql.VersionColumnDefinition;
-import io.requery.sql.gen.Generator;
-import io.requery.sql.gen.LimitGenerator;
-import io.requery.sql.gen.OffsetFetchGenerator;
-import io.requery.sql.gen.OrderByGenerator;
-import io.requery.sql.gen.UpsertMergeGenerator;
+import io.requery.query.element.QueryElement;
+import io.requery.sql.*;
+import io.requery.sql.gen.*;
 
 import java.util.Map;
 
@@ -41,6 +33,8 @@ public class Generic implements Platform {
     private final GeneratedColumnDefinition generatedColumnDefinition;
     private final LimitGenerator limitDefinition;
     private final VersionColumnDefinition versionColumnDefinition;
+    private final Generator<QueryElement<?>> insertDefinition;
+    private final Generator<Map<Expression<?>, Object>> updateDefinition;
     private final Generator<Map<Expression<?>, Object>> upsertDefinition;
     private final Generator<OrderByElement> orderByDefinition;
 
@@ -48,6 +42,8 @@ public class Generic implements Platform {
         generatedColumnDefinition = new IdentityColumnDefinition();
         limitDefinition = new OffsetFetchGenerator();
         versionColumnDefinition = new UserVersionColumnDefinition();
+        insertDefinition = new InsertGenerator();
+        updateDefinition = new UpdateGenerator();
         upsertDefinition = new UpsertMergeGenerator();
         orderByDefinition = new OrderByGenerator();
     }
@@ -104,6 +100,16 @@ public class Generic implements Platform {
     @Override
     public VersionColumnDefinition versionColumnDefinition() {
         return versionColumnDefinition;
+    }
+
+    @Override
+    public Generator<QueryElement<?>> insertGenerator() {
+        return insertDefinition;
+    }
+
+    @Override
+    public Generator<Map<Expression<?>, Object>> updateGenerator() {
+        return updateDefinition;
     }
 
     @Override

--- a/requery/src/main/java/io/requery/sql/platform/Generic.java
+++ b/requery/src/main/java/io/requery/sql/platform/Generic.java
@@ -20,6 +20,19 @@ import io.requery.query.Expression;
 import io.requery.query.element.LimitedElement;
 import io.requery.query.element.OrderByElement;
 import io.requery.query.element.QueryElement;
+import io.requery.sql.GeneratedColumnDefinition;
+import io.requery.sql.IdentityColumnDefinition;
+import io.requery.sql.Mapping;
+import io.requery.sql.Platform;
+import io.requery.sql.UserVersionColumnDefinition;
+import io.requery.sql.VersionColumnDefinition;
+import io.requery.sql.gen.Generator;
+import io.requery.sql.gen.InsertGenerator;
+import io.requery.sql.gen.LimitGenerator;
+import io.requery.sql.gen.OffsetFetchGenerator;
+import io.requery.sql.gen.OrderByGenerator;
+import io.requery.sql.gen.UpdateGenerator;
+import io.requery.sql.gen.UpsertMergeGenerator;
 
 import java.util.Map;
 

--- a/requery/src/main/java/io/requery/sql/platform/PlatformDelegate.java
+++ b/requery/src/main/java/io/requery/sql/platform/PlatformDelegate.java
@@ -19,6 +19,7 @@ package io.requery.sql.platform;
 import io.requery.query.Expression;
 import io.requery.query.element.LimitedElement;
 import io.requery.query.element.OrderByElement;
+import io.requery.query.element.QueryElement;
 import io.requery.sql.GeneratedColumnDefinition;
 import io.requery.sql.Mapping;
 import io.requery.sql.Platform;
@@ -95,6 +96,16 @@ public class PlatformDelegate implements Platform {
     @Override
     public VersionColumnDefinition versionColumnDefinition() {
         return platform.versionColumnDefinition();
+    }
+
+    @Override
+    public Generator<QueryElement<?>> insertGenerator() {
+        return platform.insertGenerator();
+    }
+
+    @Override
+    public Generator<Map<Expression<?>, Object>> updateGenerator() {
+        return platform.updateGenerator();
     }
 
     @Override


### PR DESCRIPTION
For Customizing insert, update sql statement (ex. Apache Phoenix support `UPSERT` only)