### PR TITLE
Enable @Version use with method attributes

### DIFF
--- a/requery/src/main/java/io/requery/Version.java
+++ b/requery/src/main/java/io/requery/Version.java
@@ -21,13 +21,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Defines a version attribute for optimistic locking. Field type must be a integer or long.
  */
 @Documented
-@Target(FIELD)
+@Target({FIELD, METHOD})
 @Retention(RUNTIME)
 public @interface Version {
 }


### PR DESCRIPTION
I apologize if this has been proposed before and `@Version` is only `ElementType.FIELD` for a reason—I looked through the issues and couldn't find any prior discussion.

It appears that `@Version` is the only attribute member annotation whose target is `FIELD` rather than `{FIELD, METHOD}`. I did a quick read through [AttributeMember](https://github.com/requery/requery/blob/master/requery-processor/src/main/java/io/requery/processor/AttributeMember.java) and couldn't see any reason not to add `METHOD` as a valid annotation target.