### PR TITLE
use column transformer for EXCLUDED column name on upsert query of PostgreSQL

### DIFF
--- a/requery/src/main/java/io/requery/sql/platform/PostgresSQL.java
+++ b/requery/src/main/java/io/requery/sql/platform/PostgresSQL.java
@@ -230,7 +230,8 @@ public class PostgresSQL extends Generic {
                     @Override
                     public void append(QueryBuilder qb, Expression<?> value) {
                         qb.attribute((Attribute) value);
-                        qb.append("= EXCLUDED." + value.getName());
+                        qb.append("= EXCLUDED.");
+                        qb.attribute((Attribute) value);
                     }
                 });
         }


### PR DESCRIPTION

Requery does not currently use the column transformer when generating EXCLUDED column name in Postgres.

Therefore, when specifying a column transformer that makes the column name a snake case,  Requery generate a SQL as bellow:

```
insert into test (id, message_title) values (?, ?) on conflict (id) do update set id = EXCLUDED.id, message_title = EXCLUDED.messageTitle
```

This query does not work well because the column name used in EXCLUDED clause wasn’t converted correctly (it must be a ‘message_title’, but is a ‘messageTitle’).

In my patch, I changed a UpsertOnConflictDoUpdate class to use a column transformer when generating EXCLUDED column names, so it generates a SQL as bellow:

```
insert into test (id, message_title) values (?, ?) on conflict (id) do update set id = EXCLUDED.id, message_title = EXCLUDED.message_title  