### PR TITLE
Fix auto alias for subquery without joins

### DIFF
--- a/requery/src/main/java/io/requery/sql/gen/DefaultOutput.java
+++ b/requery/src/main/java/io/requery/sql/gen/DefaultOutput.java
@@ -94,7 +94,8 @@ public class DefaultOutput implements Output {
         aliases = inheritedAliases == null ? new Aliases() : inheritedAliases;
         Set<Expression<?>> from = query.fromExpressions();
         Set<?> joins = query.joinElements();
-        autoAlias = from.size() > 1 || (joins != null && joins.size() > 0);
+        autoAlias = inheritedAliases != null ||
+                from.size() > 1 || (joins != null && joins.size() > 0);
         statementGenerator.write(this, query);
         return qb.toString();
     }


### PR DESCRIPTION
Need to use table from main query in where condition of subquery.

Example after fix:
`select a.id from table_a a
  left join table_b b on a.id = b.outer_id
  left join table_c c on a.id = c.outer_id
where c.id in (select max(d.id)
                     from table_d d
                     where d.outer_id = a.id))
`

Without fix:
`select a.id from table_a a
  left join table_b b on a.id = b.outer_id
  left join table_c c on a.id = c.outer_id
where c.id in (select max(id))
                     from table_d
                     where outer_id = id))`

